### PR TITLE
new search

### DIFF
--- a/config/Config.js
+++ b/config/Config.js
@@ -85,6 +85,11 @@ export default {
   truthyParams: ['true', 'yes', 'y', '1'],
   /** Things that will be interpreted as false for the boolean command parameter */
   falsyParams: ['false', 'no', 'n', '0'],
+  /** Object with options for ufuzzy, see https://github.com/leeoniya/uFuzzy#options */
+  searchOptions: {
+    intraMode: 1,
+    alpha: "a-zа-яё"
+  },
   /** Represents default minimal similarity value at which nickname to
    * login translation will be successful. Used in nickname to login
    * translation in commands. 0.4 is the default value */

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "dice-similarity-coeff": "^1.1.1",
+        "@leeoniya/ufuzzy": "^1.0.14",
         "dotenv": "^16.0.0",
         "node-fetch": "^3.2.4",
         "pg": "^8.7.3",
@@ -58,6 +58,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@leeoniya/ufuzzy": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@leeoniya/ufuzzy/-/ufuzzy-1.0.14.tgz",
+      "integrity": "sha512-/xF4baYuCQMo+L/fMSUrZnibcu0BquEGnbxfVPiZhs/NbJeKj4c/UmFpQzW9Us0w45ui/yYW3vyaqawhNYsTzA=="
     },
     "node_modules/@opencensus/core": {
       "version": "0.0.9",
@@ -676,11 +681,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/dice-similarity-coeff": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/dice-similarity-coeff/-/dice-similarity-coeff-1.1.1.tgz",
-      "integrity": "sha512-58GtX08RZnDAalGIlEprkjZSpEbLacHwxGNDrT93B9mEzivauXXwE0rC0kB5x8grsUTgNakHpQBmHc06hvlujQ=="
     },
     "node_modules/diff": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "dice-similarity-coeff": "^1.1.1",
+    "@leeoniya/ufuzzy": "^1.0.14",
     "dotenv": "^16.0.0",
     "node-fetch": "^3.2.4",
     "pg": "^8.7.3",

--- a/plugins/commands/src/AdminCommands.ts
+++ b/plugins/commands/src/AdminCommands.ts
@@ -1,18 +1,18 @@
 import config from '../config/AdminCommands.config.js'
-import {actions} from '../../actions/Actions.js'
+import { actions } from '../../actions/Actions.js'
 
 const commands: tm.Command[] = [
   {
     aliases: config.kick.aliases,
     help: config.kick.help,
-    params: [{name: 'login'}, {name: 'reason', type: 'multiword', optional: true}],
+    params: [{ name: 'login', type: 'player' }, { name: 'reason', type: 'multiword', optional: true }],
     callback: actions.kick,
     privilege: config.kick.privilege
   },
   {
     aliases: config.mute.aliases,
     help: config.mute.help,
-    params: [{name: 'login'}, {name: 'duration', type: 'time', optional: true}, {
+    params: [{ name: 'login', type: 'offlinePlayer' }, { name: 'duration', type: 'time', optional: true }, {
       name: 'reason',
       type: 'multiword',
       optional: true
@@ -23,42 +23,42 @@ const commands: tm.Command[] = [
   {
     aliases: config.unmute.aliases,
     help: config.unmute.help,
-    params: [{name: 'login'}],
+    params: [{ name: 'login', type: 'offlinePlayer' }],
     callback: actions.unmute,
     privilege: config.unmute.privilege
   },
   {
     aliases: config.forcespec.aliases,
     help: config.forcespec.help,
-    params: [{name: 'login'}],
+    params: [{ name: 'login', type: 'player' }],
     callback: actions.forceSpectator,
     privilege: config.forcespec.privilege
   },
   {
     aliases: config.forceplay.aliases,
     help: config.forceplay.help,
-    params: [{name: 'login'}],
+    params: [{ name: 'login', type: 'player' }],
     callback: actions.forcePlay,
     privilege: config.forceplay.privilege
   },
   {
     aliases: config.kickghost.aliases,
     help: config.kickghost.help,
-    params: [{name: 'login'}],
+    params: [{ name: 'login' }],
     callback: (info: tm.MessageInfo, login: string): void => {
       tm.sendMessage(tm.utils.strVar(config.kickghost.text, {
         title: info.title,
         adminName: tm.utils.strip(info.nickname),
         name: login
       }), config.kickghost.public ? undefined : info.login)
-      tm.client.callNoRes(`Kick`, [{string: login}])
+      tm.client.callNoRes(`Kick`, [{ string: login }])
     },
     privilege: config.kickghost.privilege
   },
   {
     aliases: config.ban.aliases,
     help: config.ban.help,
-    params: [{name: 'login'}, {name: 'duration', type: 'time', optional: true}, {
+    params: [{ name: 'login', type: 'player' }, { name: 'duration', type: 'time', optional: true }, {
       name: 'reason',
       type: 'multiword',
       optional: true
@@ -69,14 +69,14 @@ const commands: tm.Command[] = [
   {
     aliases: config.unban.aliases,
     help: config.unban.help,
-    params: [{name: 'login'}],
+    params: [{ name: 'login', type: 'offlinePlayer' }],
     callback: actions.unban,
     privilege: config.unban.privilege
   },
   {
     aliases: config.blacklist.aliases,
     help: config.blacklist.help,
-    params: [{name: 'login'}, {name: 'duration', type: 'time', optional: true}, {
+    params: [{ name: 'login', type: 'offlinePlayer' }, { name: 'duration', type: 'time', optional: true }, {
       name: 'reason',
       type: 'multiword',
       optional: true
@@ -87,30 +87,30 @@ const commands: tm.Command[] = [
   {
     aliases: config.unblacklist.aliases,
     help: config.unblacklist.help,
-    params: [{name: 'login'}],
+    params: [{ name: 'login', type: 'offlinePlayer' }],
     callback: actions.unblacklist,
     privilege: config.unblacklist.privilege
   },
   {
     aliases: config.addguest.aliases,
     help: config.addguest.help,
-    params: [{name: 'login'}],
+    params: [{ name: 'login', type: 'offlinePlayer' }],
     callback: actions.addGuest,
     privilege: config.addguest.privilege
   },
   {
     aliases: config.rmguest.aliases,
     help: config.rmguest.help,
-    params: [{name: 'login'}],
+    params: [{ name: 'login', type: 'offlinePlayer' }],
     callback: actions.removeGuest,
     privilege: config.rmguest.privilege
   },
   {
     aliases: config.loadmatchsettings.aliases,
     help: config.loadmatchsettings.help,
-    params: [{name: 'fileName', type: 'multiword',}],
+    params: [{ name: 'fileName', type: 'multiword', }],
     callback: async (info: tm.MessageInfo, fileName: string) => {
-      const res = await tm.client.call(`LoadMatchSettings`, [{string: fileName}])
+      const res = await tm.client.call(`LoadMatchSettings`, [{ string: fileName }])
       if (res instanceof Error) {
         tm.sendMessage(config.loadmatchsettings.error, info.login)
         return
@@ -128,10 +128,10 @@ const commands: tm.Command[] = [
   {
     aliases: config.savematchsettings.aliases,
     help: config.savematchsettings.help,
-    params: [{name: 'fileName', type: 'multiword', optional: true}],
+    params: [{ name: 'fileName', type: 'multiword', optional: true }],
     callback: async (info: tm.MessageInfo, fileName?: string) => {
       fileName = fileName || tm.config.controller.matchSettingsFile
-      const res = await tm.client.call(`SaveMatchSettings`, [{string: fileName}])
+      const res = await tm.client.call(`SaveMatchSettings`, [{ string: fileName }])
       if (res instanceof Error) {
         tm.sendMessage(config.savematchsettings.error, info.login)
         return

--- a/plugins/maplist/Maplist.ts
+++ b/plugins/maplist/Maplist.ts
@@ -72,7 +72,7 @@ function removeMap(map: tm.MapRemovedInfo): void {
   for (const e of updateListeners) { e('remove', map) }
 }
 
-function addOrRemove(map: tm.MapAddedInfo | tm.MapAddedInfo[], fun: Function):void {
+function addOrRemove(map: tm.MapAddedInfo | tm.MapAddedInfo[], fun: Function): void {
   if (!Array.isArray(map)) {
     fun(map)
     return
@@ -95,11 +95,11 @@ tm.addListener('JukeboxChanged', (list): void => {
 
 tm.addListener('Startup', initialize)
 
-tm.addListener('MapAdded', (map: tm.MapAddedInfo | tm.MapAddedInfo[]):void => {
+tm.addListener('MapAdded', (map: tm.MapAddedInfo | tm.MapAddedInfo[]): void => {
   addOrRemove(map, insertMap)
 })
 
-tm.addListener('MapRemoved', (map: tm.MapRemovedInfo | tm.MapRemovedInfo[]):void => {
+tm.addListener('MapRemoved', (map: tm.MapRemovedInfo | tm.MapRemovedInfo[]): void => {
   addOrRemove(map, removeMap)
 })
 
@@ -214,9 +214,10 @@ export const maplist = {
    */
   searchByName: (query: string): Readonly<tm.Map>[] => {
     let list: tm.Map[] | undefined = cache.find(a => a.query === query && a.type === 'name')?.list
+    let indices: number[]
     if (list === undefined) {
-      list = (tm.utils.matchString(query, authorSort, 'name', true))
-        .filter(a => a.value > config.searchMinSimilarityValue).map(a => a.obj)
+      indices = tm.utils.matchString(query, authorSort.map(a => a.name))
+      list = indices.map(a => authorSort[a])
       cache.unshift({ query, list, type: 'name' })
       cache.length = Math.min(config.cacheSize, cache.length)
     }
@@ -230,9 +231,10 @@ export const maplist = {
    */
   searchByAuthor: (query: string): Readonly<tm.Map>[] => {
     let list: tm.Map[] | undefined = cache.find(a => a.query === query && a.type === 'author')?.list
+    let indices: number[]
     if (list === undefined) {
-      list = (tm.utils.matchString(query, nameSort, 'author', true))
-        .filter(a => a.value > config.searchMinSimilarityValue).map(a => a.obj)
+      indices = tm.utils.matchString(query, authorSort.map(a => a.author))
+      list = indices.map(a => authorSort[a])
       cache.unshift({ query, list, type: 'author' })
       cache.length = Math.min(config.cacheSize, cache.length)
     }

--- a/plugins/music/ui/SongList.component.ts
+++ b/plugins/music/ui/SongList.component.ts
@@ -115,9 +115,9 @@ export default class SongList extends PopupWindow<DisplayParams> {
     }
   }
 
-  private getSearchResult(query: string, target: SearchTarget): (Song & { index: number })[] {
-    return (tm.utils.matchString(query, this.songs, target, true))
-      .filter(a => a.value > config.searchMinSimilatiryValue).map(a => a.obj)
+  private getSearchResult(query: string, target: SearchTarget) {
+    let indices: number[] = tm.utils.matchString(query, this.songs.map(a => a[target]))
+    return indices.map(a => this.songs[a])
   }
 
   protected async constructContent(login: string, params?: DisplayParams, privilege = 0): Promise<string> {

--- a/plugins/music/ui/SongList.config.js
+++ b/plugins/music/ui/SongList.config.js
@@ -29,5 +29,4 @@ export default {
     margin: 0.15,
     headerBackground: "333C"
   },
-  searchMinSimilatiryValue: 0.1
 }

--- a/plugins/ui/dynamic_components/Commandlist.component.ts
+++ b/plugins/ui/dynamic_components/Commandlist.component.ts
@@ -136,22 +136,21 @@ export default class CommandList extends PopupWindow<DisplayParams> {
   }
 
   openWithQuery(login: string, privilege: number, query: string) {
-    const commands = [this.userCommands, this.opCommands, this.adminCommands, this.masteradminCommands,
-      this.ownerCommands].slice(0, privilege + 1).flat(1)
+    const commands = [this.userCommands, this.opCommands, this.adminCommands, this.masteradminCommands, this.ownerCommands].slice(0, privilege + 1).flat(1)
     const aliases = commands.map(a => a.aliases).flat(1)
-    const matchedAliases = tm.utils.matchString(query, aliases)
-    const aliasValues: ({ obj: tm.Command, value: number })[] = []
-    if(config.aliasSearch) {
+    const matchedAliases = []
+    let aliasIndices: number[]
+    if (config.aliasSearch) {
+      aliasIndices = tm.utils.matchString(query, aliases)
       for (const e of commands) {
-        const value = matchedAliases.find((a) => e.aliases.includes(a.str))?.value
-        if (value !== undefined) {
-          aliasValues.push({ obj: e, value })
+        if (aliasIndices.map(a => aliases[a]).find(a => e.aliases.includes(a))) {
+          matchedAliases.push(e)
         }
       }
     }
-    const list: tm.Command[] = [...tm.utils.matchString(query, commands, "help"), ...aliasValues]
-      .sort((a, b) => b.value - a.value).filter(a => a.value > config.minimumMatchSimilarity).map(a => a.obj)
-      .filter((a, i, arr) => arr.indexOf(a) === i)
+    let indices: number[]
+    indices = tm.utils.matchString(query, commands.map(a => a.help ?? ''))
+    const list: tm.Command[] = [...indices.map(a => commands[a]), ...matchedAliases].filter((a, i, arr) => arr.indexOf(a) === i)
     if (list.length === 0) {
       tm.sendMessage(tm.utils.strVar(config.noMatchesMessage, { query }), login)
       return

--- a/plugins/ui/dynamic_components/Commandlist.config.js
+++ b/plugins/ui/dynamic_components/Commandlist.config.js
@@ -58,6 +58,5 @@ export default {
     privilege: 0
   },
   noMatchesMessage: `${p.error}Nothing found for ${p.highlight}#{query}${p.error}.`,
-  minimumMatchSimilarity: 0.1, // The higher it is the less results are considered matching
   aliasSearch: true // Whether to search for alias on query
 }

--- a/plugins/ui/dynamic_components/admin_windows/Banlist.component.ts
+++ b/plugins/ui/dynamic_components/admin_windows/Banlist.component.ts
@@ -21,10 +21,10 @@ export default class Banlist extends PopupWindow<number> {
     this.paginator.onPageChange = (login, page, info) => {
       this.displayToPlayer(login, page, `${page}/${this.paginator.pageCount}`, info.privilege)
     }
-    addManialinkListener(this.openId + 1000, 1000, (info, offset) => {
-      const target = tm.admin.banlist[offset]
+    addManialinkListener(this.openId + 1000, 1000, async (info, offset) => {
+      const target = await tm.players.fetch(tm.admin.banlist[offset].login)
       if (target === undefined) { return }
-      actions.unban(info, target.login)
+      actions.unban(info, target)
     })
     tm.addListener(['Ban', 'Unban'], () => {
       this.paginator.setPageCount(Math.ceil(tm.admin.banCount / (config.entries - 1)))

--- a/plugins/ui/dynamic_components/admin_windows/Blacklist.component.ts
+++ b/plugins/ui/dynamic_components/admin_windows/Blacklist.component.ts
@@ -21,10 +21,10 @@ export default class Blacklist extends PopupWindow<number> {
     this.paginator.onPageChange = (login, page, info) => {
       this.displayToPlayer(login, page, `${page}/${this.paginator.pageCount}`, info.privilege)
     }
-    addManialinkListener(this.openId + 1000, 1000, (info, offset) => {
-      const target = tm.admin.blacklist[offset]
+    addManialinkListener(this.openId + 1000, 1000, async (info, offset) => {
+      const target = await tm.players.fetch(tm.admin.blacklist[offset].login)
       if (target === undefined) { return }
-      actions.unblacklist(info, target.login)
+      actions.unblacklist(info, target)
     })
     tm.addListener(['Blacklist', 'Unblacklist'], () => {
       this.paginator.setPageCount(Math.ceil(tm.admin.blacklistCount / (config.entries - 1)))

--- a/plugins/ui/dynamic_components/admin_windows/Guestlist.component.ts
+++ b/plugins/ui/dynamic_components/admin_windows/Guestlist.component.ts
@@ -21,10 +21,10 @@ export default class Guestlist extends PopupWindow<number> {
     this.paginator.onPageChange = (login, page, info) => {
       this.displayToPlayer(login, page, `${page}/${this.paginator.pageCount}`, info.privilege)
     }
-    addManialinkListener(this.openId + 1000, 1000, (info, offset) => {
-      const target = tm.admin.guestlist[offset]
+    addManialinkListener(this.openId + 1000, 1000, async (info, offset) => {
+      const target = await tm.players.fetch(tm.admin.guestlist[offset].login)
       if (target === undefined) { return }
-      actions.removeGuest(info, target.login)
+      actions.removeGuest(info, target)
     })
     tm.addListener(['AddGuest', 'RemoveGuest'], () => {
       this.paginator.setPageCount(Math.ceil(tm.admin.guestCount / (config.entries - 1)))

--- a/plugins/ui/dynamic_components/admin_windows/Mutelist.component.ts
+++ b/plugins/ui/dynamic_components/admin_windows/Mutelist.component.ts
@@ -21,10 +21,10 @@ export default class Mutelist extends PopupWindow<number> {
     this.paginator.onPageChange = (login, page, info) => {
       this.displayToPlayer(login, page, `${page}/${this.paginator.pageCount}`, info.privilege)
     }
-    addManialinkListener(this.openId + 1000, 1000, (info, offset) => {
-      const target = tm.admin.mutelist[offset]
+    addManialinkListener(this.openId + 1000, 1000, async (info, offset) => {
+      const target = await tm.players.fetch(tm.admin.mutelist[offset].login)
       if (target === undefined) { return }
-      actions.unmute(info, target.login)
+      actions.unmute(info, target)
     })
     tm.addListener(['Mute', 'Unmute'], () => {
       this.paginator.setPageCount(Math.ceil(tm.admin.muteCount / (config.entries - 1)))

--- a/plugins/ui/dynamic_components/admin_windows/Playerlist.component.ts
+++ b/plugins/ui/dynamic_components/admin_windows/Playerlist.component.ts
@@ -47,44 +47,44 @@ export default class PlayerList extends PopupWindow<{ page: number, privilege: n
     addManialinkListener(this.openId + this.actions.kick, 1000, (info, offset) => {
       const target = tm.players.list[offset]
       if (target === undefined) { return }
-      actions.kick(info, target.login)
+      actions.kick(info, target)
     })
     addManialinkListener(this.openId + this.actions.forceSpec, 1000, (info, offset) => {
       const target = tm.players.list[offset]
       if (target === undefined) { return }
       if (target.isSpectator) {
-        actions.forcePlay(info, target.login)
+        actions.forcePlay(info, target)
       } else {
-        actions.forceSpectator(info, target.login)
+        actions.forceSpectator(info, target)
       }
     })
     addManialinkListener(this.openId + this.actions.mute, 1000, (info, offset) => {
       const target = tm.players.list[offset]
       if (target === undefined) { return }
       if (tm.admin.getMute(target.login) === undefined) {
-        actions.mute(info, target.login)
+        actions.mute(info, target)
       } else {
-        actions.unmute(info, target.login)
+        actions.unmute(info, target)
       }
     })
     addManialinkListener(this.openId + this.actions.addGuest, 1000, (info, offset) => {
       const target = tm.players.list[offset]
       if (target === undefined) { return }
       if (tm.admin.getGuest(target.login) === undefined) {
-        actions.addGuest(info, target.login)
+        actions.addGuest(info, target)
       } else {
-        actions.removeGuest(info, target.login)
+        actions.removeGuest(info, target)
       }
     })
     addManialinkListener(this.openId + this.actions.blacklist, 1000, (info, offset) => {
       const target = tm.players.list[offset]
       if (target === undefined) { return }
-      actions.blacklist(info, target.login)
+      actions.blacklist(info, target)
     })
     addManialinkListener(this.openId + this.actions.ban, 1000, (info, offset) => {
       const target = tm.players.list[offset]
       if (target === undefined) { return }
-      actions.ban(info, target.login)
+      actions.ban(info, target)
     })
   }
 

--- a/src/Listeners.ts
+++ b/src/Listeners.ts
@@ -312,6 +312,9 @@ export class Listeners {
     {
       event: 'TrackMania.ChallengeListModified',
       callback: async ([currentIndex, nextIndex, isListModified]: [number, number, boolean]): Promise<void> => {
+        if (config.manualMapLoading) {
+          return
+        }
         // [0] = CurChallengeIndex, [1] = NextChallengeIndex, [2] = IsListModified
         Client.callNoRes('SaveMatchSettings', [{ string: config.matchSettingsFile }])
         if(config.updateMatchSettingsOnChange && isListModified) {

--- a/src/Namespace.ts
+++ b/src/Namespace.ts
@@ -782,7 +782,7 @@ declare global {
       "RecordsPrefetch": readonly Readonly<Record>[]
       "VotesPrefetch": readonly Readonly<Vote>[]
       "MapAdded": MapAddedInfo | MapAddedInfo[]
-      "MapRemoved": MapRemovedInfo | MapRemovedInfo []
+      "MapRemoved": MapRemovedInfo | MapRemovedInfo[]
       "BillUpdated": BillUpdatedInfo
       "MatchSettingsUpdated": readonly Readonly<Map>[]
       "PrivilegeChanged": PrivilegeChangedInfo

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -6,6 +6,7 @@ import { PlayerService } from "./services/PlayerService.js"
 import colours from './data/Colours.js'
 import { palette } from '../config/PrefixesAndPalette.js'
 import config from '../config/Config.js'
+import { Logger } from './Logger.js'
 import ufuzzy from "@leeoniya/ufuzzy"
 
 const uf = new ufuzzy(config.searchOptions)
@@ -323,9 +324,11 @@ export const Utils = {
             resolve(true)
             break
           case 'refused':
+            Logger.error('Transaction refused')
             resolve(new Error(`Transaction refused`))
             break
           case 'error':
+            Logger.error('Error: ' + errorString)
             resolve(new Error(errorString ?? 'error'))
         }
       }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -551,51 +551,6 @@ export const Utils = {
 
 }
 
-// /**
-//  * Checks similarity of given strings, returns best matches sorted based on similarity.
-//  * @param searchString String to compare possible matches to
-//  * @param possibleMatches Array of strings to sort by similarity
-//  * @param stripSpecialChars If true special characters get in strings get replaced with latin if possible
-//  * @returns Array of objects containing string and its similarity value
-//  */
-// function matchString(searchString: string, possibleMatches: string[], stripSpecialChars?: true): { str: string, value: number }[]
-// /**
-//  * Checks similarity of given strings in an array of objects, returns best matches sorted based on similarity.
-//  * @param searchString String to compare possible matches to
-//  * @param possibleMatches Array of objects to sort by similarity
-//  * @param key Key in objects containing the string to compare
-//  * @param stripSpecialChars If true special characters get in strings get replaced with latin if possible
-//  * @returns Array of objects containing object and its similarity value
-//  */
-// function matchString<T extends { [key: string]: any }>
-//   (searchString: string, possibleMatches: T[], key: keyof T, stripSpecialChars?: true): { obj: T, value: number }[]
-// function matchString<T extends { [key: string]: any }>
-//   (searchString: string, possibleMatches: string[] | T[], arg?: keyof T | true, stripSpecialChars?: true)
-//   : { str: string, value: number }[] | { obj: T, value: number }[] {
-//   if (possibleMatches.length === 0) { return [] }
-//   if (arg === undefined || typeof arg === 'boolean') {
-//     const stripSpecialChars = arg
-//     const arr: { str: string, value: number }[] = []
-//     for (const e of possibleMatches) {
-//       arr.push({
-//         str: e as any, value: dsc.twoStrings(searchString, stripSpecialChars === true ?
-//           Utils.stripSpecialChars(Utils.strip(e as string)) : e)
-//       })
-//     }
-//     return arr.sort((a, b): number => b.value - a.value)
-//   } else {
-//     const key = arg
-//     const arr: { obj: T, value: number }[] = []
-//     for (const e of possibleMatches) {
-//       arr.push({
-//         obj: e as any, value: dsc.twoStrings(searchString, stripSpecialChars === true ?
-//           Utils.stripSpecialChars(Utils.strip((e as any)[key])) : (e as any)[key])
-//       })
-//     }
-//     return arr.sort((a, b): number => b.value - a.value)
-//   }
-// }
-
 /** 
  * Replaces #{variableName} in string with given variables.
  * @param str String to replace #{variableName} in
@@ -634,9 +589,6 @@ function strVar(str: string, vars: { [name: string]: any }): string {
   }
   return str
 }
-
-
-// TODO @lythx ensure compatibility in all instances PLEASE
 
 /**
  * Searches for a given string in a given array of values

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,5 +1,4 @@
 import { Client } from "./client/Client.js"
-import dsc from 'dice-similarity-coeff'
 import specialCharmap from './data/SpecialCharmap.js'
 import countries from './data/Countries.js'
 import { Events } from './Events.js'
@@ -7,6 +6,9 @@ import { PlayerService } from "./services/PlayerService.js"
 import colours from './data/Colours.js'
 import { palette } from '../config/PrefixesAndPalette.js'
 import config from '../config/Config.js'
+import ufuzzy from "@leeoniya/ufuzzy"
+
+const uf = new ufuzzy(config.searchOptions)
 
 const bills: { id: number, callback: ((status: 'error' | 'refused' | 'accepted', errorString?: string) => void) }[] = []
 Events.addListener('BillUpdated', (info: tm.BillUpdatedInfo): void => {
@@ -396,7 +398,7 @@ export const Utils = {
       if (i === -1) res = str
       else res = this.decodeURI(str.slice(0, i)) + "..."
     }
-    return res.replace(/&amp;|&quot;|&apos;|&gt;|&lt;|\+/g, (m): string => {return map[m as keyof typeof map]})
+    return res.replace(/&amp;|&quot;|&apos;|&gt;|&lt;|\+/g, (m): string => { return map[m as keyof typeof map] })
   },
 
   /**
@@ -422,25 +424,17 @@ export const Utils = {
       minDifferenceBetweenMatches: config.nicknameToLoginMinimumDifferenceBetweenMatches
     }): tm.Player | undefined {
     const players = PlayerService.players
-    const strippedNicknames: { strippedNickname: string, player: tm.Player }[] = []
+    const strippedNicknames = []
     for (const e of players) {
-      strippedNicknames.push({ strippedNickname: this.stripSpecialChars(Utils.strip(e.nickname).toLowerCase()), player: e })
+      strippedNicknames.push(this.stripSpecialChars(Utils.strip(e.nickname)))
     }
-    const matches: { player: tm.Player, value: number }[] = []
-    for (const e of strippedNicknames) {
-      const value = dsc.twoStrings(e.strippedNickname, nickname.toLowerCase())
-      if (value > options.similarityGoal) {
-        matches.push({ player: e.player, value })
-      }
-    }
+    const matches = []
+    const indices = this.matchString(nickname, strippedNicknames)
+    matches.push(indices.map(a => players[a]))
     if (matches.length === 0) {
       return undefined
     }
-    const s = matches.sort((a, b): number => b.value - a.value)
-    if (s[0].value - s?.[1]?.value ?? 0 < options.minDifferenceBetweenMatches) {
-      return undefined
-    }
-    return s[0].player
+    return matches[0][0]
   },
 
   /**
@@ -557,50 +551,50 @@ export const Utils = {
 
 }
 
-/**
- * Checks similarity of given strings, returns best matches sorted based on similarity.
- * @param searchString String to compare possible matches to
- * @param possibleMatches Array of strings to sort by similarity
- * @param stripSpecialChars If true special characters get in strings get replaced with latin if possible
- * @returns Array of objects containing string and its similarity value
- */
-function matchString(searchString: string, possibleMatches: string[], stripSpecialChars?: true): { str: string, value: number }[]
-/**
- * Checks similarity of given strings in an array of objects, returns best matches sorted based on similarity.
- * @param searchString String to compare possible matches to
- * @param possibleMatches Array of objects to sort by similarity
- * @param key Key in objects containing the string to compare
- * @param stripSpecialChars If true special characters get in strings get replaced with latin if possible
- * @returns Array of objects containing object and its similarity value
- */
-function matchString<T extends { [key: string]: any }>
-  (searchString: string, possibleMatches: T[], key: keyof T, stripSpecialChars?: true): { obj: T, value: number }[]
-function matchString<T extends { [key: string]: any }>
-  (searchString: string, possibleMatches: string[] | T[], arg?: keyof T | true, stripSpecialChars?: true)
-  : { str: string, value: number }[] | { obj: T, value: number }[] {
-  if (possibleMatches.length === 0) { return [] }
-  if (arg === undefined || typeof arg === 'boolean') {
-    const stripSpecialChars = arg
-    const arr: { str: string, value: number }[] = []
-    for (const e of possibleMatches) {
-      arr.push({
-        str: e as any, value: dsc.twoStrings(searchString, stripSpecialChars === true ?
-          Utils.stripSpecialChars(Utils.strip(e as string)) : e)
-      })
-    }
-    return arr.sort((a, b): number => b.value - a.value)
-  } else {
-    const key = arg
-    const arr: { obj: T, value: number }[] = []
-    for (const e of possibleMatches) {
-      arr.push({
-        obj: e as any, value: dsc.twoStrings(searchString, stripSpecialChars === true ?
-          Utils.stripSpecialChars(Utils.strip((e as any)[key])) : (e as any)[key])
-      })
-    }
-    return arr.sort((a, b): number => b.value - a.value)
-  }
-}
+// /**
+//  * Checks similarity of given strings, returns best matches sorted based on similarity.
+//  * @param searchString String to compare possible matches to
+//  * @param possibleMatches Array of strings to sort by similarity
+//  * @param stripSpecialChars If true special characters get in strings get replaced with latin if possible
+//  * @returns Array of objects containing string and its similarity value
+//  */
+// function matchString(searchString: string, possibleMatches: string[], stripSpecialChars?: true): { str: string, value: number }[]
+// /**
+//  * Checks similarity of given strings in an array of objects, returns best matches sorted based on similarity.
+//  * @param searchString String to compare possible matches to
+//  * @param possibleMatches Array of objects to sort by similarity
+//  * @param key Key in objects containing the string to compare
+//  * @param stripSpecialChars If true special characters get in strings get replaced with latin if possible
+//  * @returns Array of objects containing object and its similarity value
+//  */
+// function matchString<T extends { [key: string]: any }>
+//   (searchString: string, possibleMatches: T[], key: keyof T, stripSpecialChars?: true): { obj: T, value: number }[]
+// function matchString<T extends { [key: string]: any }>
+//   (searchString: string, possibleMatches: string[] | T[], arg?: keyof T | true, stripSpecialChars?: true)
+//   : { str: string, value: number }[] | { obj: T, value: number }[] {
+//   if (possibleMatches.length === 0) { return [] }
+//   if (arg === undefined || typeof arg === 'boolean') {
+//     const stripSpecialChars = arg
+//     const arr: { str: string, value: number }[] = []
+//     for (const e of possibleMatches) {
+//       arr.push({
+//         str: e as any, value: dsc.twoStrings(searchString, stripSpecialChars === true ?
+//           Utils.stripSpecialChars(Utils.strip(e as string)) : e)
+//       })
+//     }
+//     return arr.sort((a, b): number => b.value - a.value)
+//   } else {
+//     const key = arg
+//     const arr: { obj: T, value: number }[] = []
+//     for (const e of possibleMatches) {
+//       arr.push({
+//         obj: e as any, value: dsc.twoStrings(searchString, stripSpecialChars === true ?
+//           Utils.stripSpecialChars(Utils.strip((e as any)[key])) : (e as any)[key])
+//       })
+//     }
+//     return arr.sort((a, b): number => b.value - a.value)
+//   }
+// }
 
 /** 
  * Replaces #{variableName} in string with given variables.
@@ -639,4 +633,31 @@ function strVar(str: string, vars: { [name: string]: any }): string {
     }
   }
   return str
+}
+
+
+// TODO @lythx ensure compatibility in all instances PLEASE
+
+/**
+ * Searches for a given string in a given array of values
+ * @param needle What string to search for
+ * @param haystack Array where to search
+ * @returns Indices that match the search
+ */
+function matchString(needle: string, haystack: string[]): number[] {
+  if (haystack.length === 0) { return [] }
+  haystack = ufuzzy.latinize(haystack)
+  const arr = []
+  const idxs = uf.filter(haystack, needle)
+  if (idxs != null && idxs.length > 0) {
+    const infoThresh = 1e4
+    if (idxs.length <= infoThresh) {
+      const info = uf.info(idxs, haystack, needle)
+      const order = uf.sort(info, haystack, needle)
+      for (let i = 0; i < order.length; i++) {
+        arr.push(info.idx[order[i]])
+      }
+    }
+  }
+  return arr
 }

--- a/src/declarations/dsc.d.ts
+++ b/src/declarations/dsc.d.ts
@@ -1,1 +1,0 @@
-declare module 'dice-similarity-coeff'

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -534,8 +534,7 @@ export class MapService {
     const index: number = setAsNextMap ? 0 : (qi === -1 ? this._queue.length : qi)
     this._queue.splice(index, 0, { map: map, isForced: true, callerLogin: caller?.login })
     Events.emit('JukeboxChanged', this.jukebox.map(a => a.map))
-    this.writeMS()
-    await this.updateNextMap()
+    this.writeMS().then(() => this.updateNextMap())
     if (caller !== undefined) {
       Logger.trace(`${Utils.strip(caller.nickname)} (${caller.login}) added map ${Utils.strip(
         map.name)} by ${map.author} to the jukebox`)
@@ -571,8 +570,7 @@ export class MapService {
     }
     this._queue.splice(index, 1)
     this.fillQueue()
-    this.writeMS()
-    await this.updateNextMap()
+    this.writeMS().then(() => this.updateNextMap())
     Events.emit('JukeboxChanged', this.jukebox.map(a => a.map))
     return true
   }

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -37,7 +37,7 @@ export class MapService {
     await this.createList()
     await this.setCurrent()
     this.fillQueue()
-    await this.writeMS()
+    await this.writeMatchSettings()
     await this.updateNextMap()
     // Recreate list when Match Settings get changed only with non-dynamic map loading
     if (!config.manualMapLoading.enabled) {
@@ -53,7 +53,7 @@ export class MapService {
   /**
    * Write MatchSettings file if dynamic map loading is enabled
    */
-  private static async writeMS() {
+  private static async writeMatchSettings() {
     if (config.manualMapLoading.enabled) {
       await ManualMapLoading.writeMS(this._current, this._queue.map(a => a.map))
     }
@@ -82,7 +82,7 @@ export class MapService {
       }
       const fileNames = new Set(await ManualMapLoading.getFileNames())
       this._maps = list.filter(a => fileNames.has(a.fileName)).map(a => ({ map: a, rand: Math.random() }))
-      .sort((a, b): number => a.rand - b.rand).map(a => a.map)
+        .sort((a, b): number => a.rand - b.rand).map(a => a.map)
       return
     }
     const mapList: any[] | Error = await Client.call('GetChallengeList', [{ int: 5000 }, { int: 0 }])
@@ -126,7 +126,7 @@ export class MapService {
     }
     // Shuffle maps array
     this._maps = [...mapsInMapList, ...mapsNotInDBObjects].map(a => ({ map: a, rand: Math.random() }))
-    .sort((a, b): number => a.rand - b.rand).map(a => a.map)
+      .sort((a, b): number => a.rand - b.rand).map(a => a.map)
     await this.repo.splitAdd(mapsNotInDBObjects)
   }
 
@@ -214,7 +214,7 @@ export class MapService {
     await this.repo.splitAdd(addedMapObjects)
     await this.repo.splitRemove(removedMaps)
     removedMaps.forEach(a => void this.remove(a))
-    await this.writeMS()
+    await this.writeMatchSettings()
     Events.emit('MapAdded', addedMapObjects)
   }
 
@@ -446,7 +446,7 @@ export class MapService {
     }
     Events.emit('MapRemoved', { ...map, callerLogin: caller?.login })
     await this.removeFromQueue(id, caller, false)
-    await this.writeMS()
+    await this.writeMatchSettings()
     return true
   }
 
@@ -534,7 +534,8 @@ export class MapService {
     const index: number = setAsNextMap ? 0 : (qi === -1 ? this._queue.length : qi)
     this._queue.splice(index, 0, { map: map, isForced: true, callerLogin: caller?.login })
     Events.emit('JukeboxChanged', this.jukebox.map(a => a.map))
-    this.writeMS().then(() => this.updateNextMap())
+    await this.writeMatchSettings()
+    void this.updateNextMap()
     if (caller !== undefined) {
       Logger.trace(`${Utils.strip(caller.nickname)} (${caller.login}) added map ${Utils.strip(
         map.name)} by ${map.author} to the jukebox`)
@@ -570,7 +571,8 @@ export class MapService {
     }
     this._queue.splice(index, 1)
     this.fillQueue()
-    this.writeMS().then(() => this.updateNextMap())
+    await this.writeMatchSettings()
+    void this.updateNextMap()
     Events.emit('JukeboxChanged', this.jukebox.map(a => a.map))
     return true
   }
@@ -589,7 +591,7 @@ export class MapService {
     }
     this.fillQueue()
     Events.emit('JukeboxChanged', this.jukebox.map(a => a.map))
-    this.writeMS()
+    this.writeMatchSettings()
     await this.updateNextMap()
     if (caller !== undefined) {
       Logger.trace(`${Utils.strip(caller.nickname)} (${caller.login}) cleared the jukebox`)

--- a/src/services/RecordService.ts
+++ b/src/services/RecordService.ts
@@ -37,10 +37,13 @@ export class RecordService {
     await this.updateQueue()
     await this.fetchAndStoreRanks()
     // Recreate list when Match Settings get changed
-    Client.addProxy(['LoadMatchSettings', 'AppendPlaylistFromMatchSettings', 'InsertPlaylistFromMatchSettings'], async (): Promise<void> => {
-      this._playerRanks.length = 0
-      await this.fetchAndStoreRanks()
-    })
+    if (!config.manualMapLoading) {
+      Client.addProxy(['LoadMatchSettings', 'AppendPlaylistFromMatchSettings', 'InsertPlaylistFromMatchSettings'],
+        async (): Promise<void> => {
+          this._playerRanks.length = 0
+          await this.fetchAndStoreRanks()
+        })
+    }
     Events.addListener('JukeboxChanged', () => this.updateQueue())
     Events.addListener('LocalRecord', (info) => {
       const ranks = this._playerRanks.filter(a => a.mapId === MapService.current.id)


### PR DESCRIPTION
improved index based search for maplist (/list), commandlist (/help) and songlist (in theory). tested on a 300000 maps set, it performs about 100 times faster (~60 seconds against ~0.5 seconds). on smaller sets, such as the 50000 maps server i tested it on, the search is essentially immediate (~0.03 seconds against ~5 seconds). ymmv of course, but i dont think it can be made much quicker.

other changes also include correct types for admin service commands to make them work with nicknametoplayer, which was apparently never used. now it is, and it allows for nickname to player (no way!) "translation".

how it works is: lets say theres a player with the nickname "michael" whose login is "73836382mich888ael", you could just type "//kick michael" and the controller will kick the correct login. obviously, if there are multiple players with similar nicknames, the closer match will be kicked but thats another story.