### PR TITLE
Update utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 /trakman/
 /tmf-config/
 /tracks/
+/.hashes.json
 
 # Bun
 bun.lockb

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app/server
 COPY --chown=1001:1001 ./config ./trakmanbk/config
 COPY --chown=1001:1001 ./plugins ./trakmanbk/plugins
 COPY --chown=1001:1001 ./src ./trakmanbk/src
-COPY --chown=1001:1001 ./Plugins.ts ./package.json ./tsconfig.json ./CHANGELOG.md ./trakmanbk/
+COPY --chown=1001:1001 ./Plugins.ts ./package.json ./tsconfig.json ./CHANGELOG.md ./Update.js ./trakmanbk/
 COPY --chown=1001:1001 --chmod=0755 ./docker_run.sh ./docker_run.sh
 # download dedicated server and remove unnecessary files
 RUN wget -O serv.zip http://files2.trackmaniaforever.com/TrackmaniaServer_2011-02-21.zip && \
@@ -18,9 +18,10 @@ RUN wget -O serv.zip http://files2.trackmaniaforever.com/TrackmaniaServer_2011-0
     unzip serv.zip && \
     rm -r serv.zip CommandLine.html ListCallbacks.html ListMethods.html \
     Readme_Dedicated.html RemoteControlExamples TrackmaniaServer.exe manialink_dedicatedserver.txt
-# get trakman dependencies and build
+# generate file hashes, get trakman dependencies and build
 WORKDIR /app/server/trakmanbk
-RUN npm i && \
+RUN node Update.js && \
+    npm i && \
     npm run build
 WORKDIR /app/server
 # backup important files to prevent them being deleted by mounting the volume

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ VOLUME /app/server/trakman
 VOLUME /app/server/.pm2/logs
 # set user back to root to be able to chown volumes in the run script
 USER root
-CMD ["/app/server/docker_run.sh"]
+ENTRYPOINT ["/app/server/docker_run.sh"]

--- a/Update.js
+++ b/Update.js
@@ -1,0 +1,132 @@
+// Update script (mostly) for docker purposes, if you use git, just do `git pull` instead
+// Usage: to perform update: `node Update.js <new version's .hashes.json>`
+// To generate hashes for files currently present: `node Update.js`
+// Exits with code 0 if successful, code 1 if an error occurred, code 2 if there are conflicts
+import fs from 'node:fs/promises'
+import crypto from 'node:crypto'
+import path from 'node:path'
+
+if (process.argv.length < 3) {
+  const hashes = JSON.stringify(Object.fromEntries(await generateHashes()))
+  console.log('Writing hashes to file...')
+  try {
+    await fs.writeFile('.hashes.json', hashes, { encoding: 'utf-8' })
+    console.log('Hashes written.')
+    process.exit()
+  } catch(e) {
+    console.log('Failed to write hashes to file.')
+    console.log(e)
+    process.exit(1)
+  }
+}
+
+try {
+  const newHashes = new Map(Object.entries(JSON.parse(await fs.readFile(process.argv[2], { encoding: 'utf-8' }))))
+  const fromPath = path.dirname(process.argv[2])
+  try {
+    const oldHashes = new Map(Object.entries(JSON.parse(await fs.readFile('.hashes.json', { encoding: 'utf-8' }))))
+    await doUpdate(fromPath, newHashes, oldHashes)
+  } catch(e) {
+    console.log('.hashes.json file does not exist.')
+    await doUpdate(fromPath, newHashes)
+  }
+} catch(e) {
+  console.log('Failed to update Trakman.')
+  console.log('Usage: node Update.js <new version\'s hashes.json>')
+  console.log(e)
+  process.exit(1)
+}
+
+async function hashFile(path) {
+  const hash = crypto.createHash('md5')
+  hash.setEncoding('base64')
+  try {
+    const f = await fs.readFile(path, { encoding: 'utf-8' })
+    hash.write(f)
+    hash.end()
+    return hash.read()
+  } catch(e) {
+    console.log('Cannot read file ' + path)
+    return ''
+  }
+}
+
+async function generateHashes() {
+  console.log('Generating hashes for current files...')
+  const entries = (await fs.readdir('./src', { recursive: true, withFileTypes: true }))
+  .concat(await fs.readdir('./plugins', { recursive: true, withFileTypes: true }))
+  .concat(await fs.readdir('./config', { recursive: true, withFileTypes: true }))
+
+  const res = new Map(
+    await Promise.all(entries.filter(a => a.isFile() && (a.name.endsWith('.js') || a.name.endsWith('.ts')))
+    .map(async (a) => {
+      const p = path.join(a.parentPath, a.name)
+      return [p, await hashFile(p)]
+    })))
+  for (const name of ['Plugins.ts', 'package.json', 'tsconfig.json', 'CHANGELOG.md', 'Update.js']) {
+    res.set(name, await hashFile(name))
+  }
+  console.log('Hashes generated.')
+  return res
+}
+
+async function doUpdate(fromPath, newHashes, oldHashes = null) {
+  const currHashes = await generateHashes()
+  const conflicts = []
+  let errorOccurred = false
+  for (const file of newHashes.keys()) {
+    const newHash = newHashes.get(file)
+    const fullFromPath = path.join(fromPath, file)
+    try {
+      // NICE NOT AT ALL CONFUSING IF STATEMENTS!!!
+      if (currHashes.has(file) && currHashes.get(file) !== newHash) {
+        if (oldHashes !== null && oldHashes.has(file)) {
+          if (oldHashes.get(file) === newHash) {
+            // no update since only the user's file is different (X Y X)
+            continue
+          } else if (oldHashes.get(file) === currHashes.get(file)) {
+            // normal update since user didn't alter the file (X X Y)
+            await fs.copyFile(fullFromPath, file)
+            continue
+          }
+        }
+        // copy the new file with the .new extension since the user modified the file, and it might have been updated (X Y Z)
+        conflicts.push(file)
+        await fs.copyFile(fullFromPath, file + '.new')
+      } else if (!currHashes.has(file)) {
+        // the file exists in the new version and not in the old
+        // make sure the directory exists
+        console.log(path.dirname(file))
+        await fs.mkdir(path.dirname(file), { recursive: true })
+        await fs.copyFile(fullFromPath, file)
+      }
+      // otherwise the file is already what it needs to be, no need to update it
+    } catch(e) {
+      console.log('Could not copy file ' + file)
+      console.log(e)
+      errorOccurred = true
+    }
+  }
+  // copy new hashes so you only have to update once
+  try {
+    await fs.copyFile(process.argv[2], '.hashes.json')
+  } catch (e) {
+    console.log('Failed to copy new hashes.')
+    console.log(e)
+    process.exit(1)
+  }
+  if (errorOccurred) {
+    console.log('Errors occurred during update, exiting...')
+    process.exit(1)
+  }
+  if (conflicts.length > 0) {
+    console.log('!!! Update conflicts, make sure to fix them by comparing your files to files ending in .new !!!')
+    console.log('If you do not fix these conflicts, the controller might fail to start or crash.')
+    console.log('Affected files: ')
+    conflicts.forEach(name => console.log(name))
+    console.log('_____________________________________')
+    process.exit(2)
+  }
+  console.log('Update successful.')
+  process.exit()
+}

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -34,7 +34,13 @@ else
 fi
 # copy over trakman directory
 if find /app/server/trakman -mindepth 1 -maxdepth 1 | read; then
-  echo 'Trakman exists, skipping initial setup.'
+  echo 'Trakman exists. Attempting update...'
+  cd trakman || exit
+  node Update.js /app/server/trakmanbk/.hashes.json
+  if [ $? -gt 0 ]; then
+    exit
+  fi
+  cd ..
   rm -r trakmanbk
 else
   echo 'Setting up trakman...'

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -38,6 +38,7 @@ if find /app/server/trakman -mindepth 1 -maxdepth 1 | read; then
   cd trakman || exit
   node Update.js /app/server/trakmanbk/.hashes.json
   if [ $? -gt 0 ]; then
+    chown server:server update.log
     echo 'Update not fully successful, please stop the container.'
     sleep 1m # wait a minute for user to read the message, or to realise something's wrong
     exit

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Do **NOT** run this script locally,
-# it is meant to only be used in the provided docker environment.
+# it is meant to only be used in the provided Docker environment.
 
 # create and copy dedicated config
 if find /app/server/GameData/Config -mindepth 1 -maxdepth 1 | read; then
@@ -8,7 +8,7 @@ if find /app/server/GameData/Config -mindepth 1 -maxdepth 1 | read; then
   rm dedicated_cfg.txt.bk
 else
   echo 'Setting up server...'
-  # cool and ugly xml replacement
+  # ugly xml replacement
   xml ed -L -u "/dedicated/authorization_levels/level[name='SuperAdmin']/password" -v "$SUPER_ADMIN_PASSWORD" dedicated_cfg.txt.bk
   xml ed -L -u "/dedicated/authorization_levels/level[name='SuperAdmin']/name" -v "$SUPER_ADMIN_NAME" dedicated_cfg.txt.bk
   ADMIN_PASS=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c"${1:-32}";echo;)
@@ -32,19 +32,22 @@ else
   echo 'Setting up tracks...'
   mv /app/server/Tracksbk/* /app/server/GameData/Tracks/
 fi
-# copy over trakman directory
+# update and copy over Trakman directory
 if find /app/server/trakman -mindepth 1 -maxdepth 1 | read; then
   echo 'Trakman exists. Attempting update...'
   cd trakman || exit
   node Update.js /app/server/trakmanbk/.hashes.json
   if [ $? -gt 0 ]; then
+    echo 'Update not fully successful, please stop the container.'
+    sleep 1m # wait a minute for user to read the message, or to realise something's wrong
     exit
   fi
   cd ..
   rm -r trakmanbk
 else
-  echo 'Setting up trakman...'
+  echo 'Setting up Trakman...'
   mv /app/server/trakmanbk/* /app/server/trakman/
+  mv /app/server/trakmanbk/.hashes.json /app/server/trakman/
 fi
 # ugly creating of files to be able to chmod and remove them later
 mkdir -p trakman/logs


### PR DESCRIPTION
Pacman-esque update utility that runs every time the docker container is started. It compares hashes of each (important) file and updates the files accordingly. There are multiple scenarios (letters refer to the original, the current and the new files respectively):

- the file has not been changed between versions and the user has not altered it (X X X)
in this case nothing is done since no update is needed
- the file has been changed between versions and the user has not altered it (X X Y)
in this case the new file is copied instead of the old one
- the file has not been changed between versions and the user has altered it (X Y X)
in this case nothing is done
- the file has been changed between versions and the user has altered it (X Y Z)
in this case the new file is copied with a .new extension for the user to manually merge later, the script also outputs this into the console and writes a file with all files that need manual merging
- the original file is newer than the new one
this happens in case the user updates their hashes or tries to downgrade to an older version of trakman, no update is performed, too bad!

The Update.js script is fairly well documented, but the user shouldn't have to run it ever anyway.