### PR TITLE
Add config option for CP Counter to not display times

### DIFF
--- a/plugins/ui/static_components/race/CpCounter.component.ts
+++ b/plugins/ui/static_components/race/CpCounter.component.ts
@@ -237,6 +237,14 @@ export default class CpCounter extends StaticComponent {
     const spectators = tm.players.get(login)?.spectators
     const logins = spectators !== undefined ? Array.from(spectators) : []
     logins.unshift(login)
+
+    let times = ''
+    if (config.times) {
+        times = `<frame posn="0 ${-(config.height + config.margin)} 2">
+                ${cpAmount === 0 ? '' : this.constructTimeXml(login, false, config.iconBottom,
+            params?.isFinish, params?.current, params?.best)}</frame>`
+    }
+
     return {
       xml: `
         <manialink id="${this.id}">
@@ -246,10 +254,7 @@ export default class CpCounter extends StaticComponent {
               ${this.header.constructXml('$' + config.colours.default + text, config.icon, config.side,
         { rectangleWidth, centerText })}
               ${counterXml}
-              <frame posn="0 ${-(config.height + config.margin)} 2">
-                ${cpAmount === 0 ? '' : this.constructTimeXml(login, false, config.iconBottom,
-          params?.isFinish, params?.current, params?.best)}
-              </frame>
+              ${times}
             </frame>
         </manialink>`, login: logins
     }

--- a/plugins/ui/static_components/race/CpCounter.config.js
+++ b/plugins/ui/static_components/race/CpCounter.config.js
@@ -11,6 +11,7 @@ export default {
   posY: -37,
   margin: cfg.margin,
   side: true,
+  times: true,
   rectangleWidth: 7.7,
   icon: icons.waypoint,
   iconBottom: icons.clock,


### PR DESCRIPTION
I prefer to use the game's CP times ui because it makes it easily possibly to compare with other players checkpoints. I added a config option so the second line can be toggled.
<img width="596" height="188" alt="image" src="https://github.com/user-attachments/assets/f5d2d547-e56b-45ff-8444-3225480681d9" />
