### PR TITLE
Create database if it doesn't exist

### DIFF
--- a/src/database/DB.ts
+++ b/src/database/DB.ts
@@ -8,22 +8,84 @@ const { Pool } = postgres
 
 export class Database {
 
-  private static readonly pool: postgres.Pool = new Pool({
-    user: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    host: process.env.DB_IP,
-    port: Number(process.env.DB_PORT),
-    connectionTimeoutMillis: 15000
-  })
+  private static pool: postgres.Pool = Database.createPool(process.env.DB_NAME ?? '')
+
   private static reconnectingPool: boolean = false
-  private static reconnectTimeout: number
-  private client: postgres.Pool | postgres.PoolClient = Database.pool
+  private static reconnectTimeout: number = 1000
+
   static dbVersion: string
   static dbSize: string
 
+  private client: postgres.Pool | postgres.PoolClient = Database.pool
+
+  private static createPool(dbName: string): postgres.Pool {
+    if (!dbName) {
+      throw new Error('DB_NAME environment variable is not set')
+    }
+
+    return new Pool({
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: dbName,
+      host: process.env.DB_IP,
+      port: Number(process.env.DB_PORT),
+      connectionTimeoutMillis: 15000
+    })
+  }
+
+  constructor() {
+    this.client = Database.pool
+  }
+
+  private static async initPoolAndDatabase(): Promise<void> {
+    const dbName = process.env.DB_NAME
+    if (!dbName) {
+      throw new Error('DB_NAME environment variable is not set')
+    }
+
+    try {
+      await this.pool.query('select 1;')
+    } catch(err: any) {
+      if (err instanceof postgres.DatabaseError && err.code === '3D000') {
+        await Logger.error(`Database "${dbName}" does not exist, attempting to create it...`, err.message)
+
+        await this.pool.end().catch(() => {
+        })
+
+        const adminPool = new Pool({
+          user: process.env.DB_USER,
+          password: process.env.DB_PASSWORD,
+          database: 'postgres',
+          host: process.env.DB_IP,
+          port: Number(process.env.DB_PORT),
+          connectionTimeoutMillis: 15000
+        })
+
+        try {
+          await adminPool.query(`CREATE DATABASE "${dbName}"`)
+          await Logger.info(`Database "${dbName}" created successfully.`)
+        } catch(createErr: any) {
+          await Logger.fatal('Failed to create database.', `Error: ${createErr.message}`, createErr.stack)
+          await adminPool.end().catch(() => {
+          })
+          throw createErr
+        } finally {
+          await adminPool.end().catch(() => {
+          })
+        }
+
+        this.pool = this.createPool(dbName)
+
+        await this.pool.query('select 1;')
+      } else {
+        throw err
+      }
+    }
+  }
+
   static async initialize(reconnectTimeout: number = 1000): Promise<void> {
     this.reconnectTimeout = reconnectTimeout
+    await this.initPoolAndDatabase()
     for (const e of createQueries) {
       await this.pool.query(e).catch(async (err: Error) => {
         await Logger.fatal(`Database create query failed.`, `Error: ${err.message}`, err.stack, `Query:`, e)
@@ -41,12 +103,15 @@ export class Database {
           `Lost connection to database, attempting to reconnect in ${this.reconnectTimeout / 1000} second(s)`)
         setTimeout(async () => {
           Logger.debug('Reconnecting to database...')
-          await this.pool.query(`select version();`).catch(async (err: Error) => {
-            await Logger.fatal('Failed to reconnect to database', err.message)
-          })
-          await this.getDBInfo()
-          Logger.info('Reconnected to database successfully')
-          this.reconnectingPool = false
+          try {
+            await this.pool.query('select version();')
+            await this.getDBInfo()
+            Logger.info('Reconnected to database successfully')
+          } catch(reErr: any) {
+            await Logger.fatal('Failed to reconnect to database', reErr.message, reErr.stack)
+          } finally {
+            this.reconnectingPool = false
+          }
         }, this.reconnectTimeout)
       } else {
         Logger.error(err)
@@ -55,9 +120,11 @@ export class Database {
   }
 
   private static async getDBInfo(): Promise<void> {
-    this.dbVersion = String((await this.pool.query(`select version();`) as any)?.rows[0]?.version?.split(` `, 2)[1])
-    this.dbSize = String((await this.pool.query(
-      `select pg_size_pretty(pg_database_size('${process.env.DB_NAME}'));`) as any)?.rows[0]?.pg_size_pretty)
+    const versionRes = await this.pool.query('select version();') as any
+    this.dbVersion = String(versionRes?.rows[0]?.version?.split(' ', 2)[1])
+
+    const sizeRes = await this.pool.query('select pg_size_pretty(pg_database_size($1));', [process.env.DB_NAME]) as any
+    this.dbSize = String(sizeRes?.rows[0]?.pg_size_pretty)
   }
 
   async enableClient(): Promise<void> {


### PR DESCRIPTION
This creates the database if it doesn't exist (makes it way easier if planning to deploy many servers).
It will crash because the logger tries to use the database before it exists, but it actually creates it. 
Not ideal but in the Docker container it restarts itself anyway, which will work then because it initializes on the first try.