### PR TITLE
Fix Nickname/Text stripping with Links/Manialinks

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -86,9 +86,9 @@ export const Utils = {
     if (str === undefined) { return '' }
     let regex: RegExp
     if (removeColours) {
-      regex = /\${1}(L|H|P)\[.*?\](.*?)\$(L|H|P)|\${1}(L|H|P)\[.*?\](.*?)|\${1}(L|H|P)(.*?)|\${1}[SHWIPLONGTZ]|\$(?:[\da-f][^$][^$]|[\da-f][^$]|[^][hlp]|(?=[][])|$)|\${1}[^\💀]/gi
+      regex = /\$(?:[lhp](?:\[.*?\])?|[iowsnmgtz<>]|[0-9a-f][^$]{0,2})/gi
     } else {
-      regex = /\${1}(L|H|P)\[.*?\](.*?)\$(L|H|P)|\${1}(L|H|P)\[.*?\](.*?)|\${1}(L|H|P)(.*?)|\${1}[SHWIPLONGTZ]/gi
+      regex = /\$(?:[lhp](?:\[.*?\])?|[iowsnmgtz<>])/gi
     }
     return str.replace('$$', '💀').replace(regex, '').replace('💀', '$$$$')
   },


### PR DESCRIPTION
I noticed that when i put a Manialink in the middle of my name (`$000.$beeиѕғ$000҂$fff$H[nsf]flø$H$bee :3`) It renders my name incorrectly:
<img width="221" height="65" alt="image" src="https://github.com/user-attachments/assets/f7137394-eee5-4bb9-aa37-7fd47685af50" />

This regex fixes that, and it's way shorter:
<img width="303" height="105" alt="image" src="https://github.com/user-attachments/assets/fb0e03f7-feb1-414a-95d2-eeed70a8ae7b" />
(as it should look like)

I've made a script iterating through the nicknames of all players that are online right now, and i didn't see any issues with it. (I asked AI to test for edge cases aswell, and it told me that this regex accounts for all of them)