### PR TITLE
Add once method to Events

### DIFF
--- a/src/Events.ts
+++ b/src/Events.ts
@@ -69,6 +69,22 @@ const removeListener = (callback: Function): void => {
 }
 
 /**
+ * Registers a one-time event listener.
+ * The callback is executed the next time the event occurs and is then removed automatically.
+ * @param event  Event name or array of event names to listen to
+ * @param callback  Function to execute when the event fires
+ */
+const once = <T extends keyof tm.Events>(event: T | (keyof tm.Events)[],
+  callback: ((params: T extends keyof tm.Events ? tm.Events[T] : any) => void | Promise<void>)): void => {
+  const onceCallback = async (params: any) => {
+    removeListener(onceCallback)
+    await callback(params)
+  }
+
+  addListener(event, onceCallback)
+}
+
+/**
  * Execute the event callbacks
  * @param event callback event name
  * @param params callback params
@@ -92,5 +108,6 @@ export const Events = {
   initialize,
   addListener,
   removeListener,
+  once,
   emit
 }

--- a/src/Trakman.ts
+++ b/src/Trakman.ts
@@ -719,6 +719,14 @@ namespace trakman {
   export const removeListener = Events.removeListener
 
   /**
+   * Adds a one-time listener for the given event.
+   * The listener is invoked at most once: after it fires, it is automatically removed.
+   * @param event Event or array of events to attach the listener to
+   * @param callback Function to execute when the event occurs
+   */
+  export const once = Events.once
+
+  /**
    * Emits ManialinkClick for given player and actionId.
    * Used for manialink interaction such as opening UI windows.
    * @param id Manialink ID


### PR DESCRIPTION
Adds a once method so we can elegantly wait for one call of a event. I need this for the RoundsService, because it has a nasty bug where Trakman crashes when there is no player in playermode after a round ends (edgecase with my AutoQueue plugin im writing)

We can then wait for one event of BeginMap if we can't obtain 'GetCurrentRanking' after several unsuccessful tries, therefore not making Trakman crash. (which is better imo)