### PR TITLE
Implement custom environment support

### DIFF
--- a/config/Config.js
+++ b/config/Config.js
@@ -100,6 +100,6 @@ export default {
   matchStringCacheSize: 10000,
   /** If haystack size exceeds this threshold `matchString()` will skip expensive haystack processing to optimize performance */
   matchStringReduxModeThreshold: 5000,
-  /** Custom map environments. If a map has an environment that is not in this list, it will be marked as "Other" */
+  /** Custom map environments. If a map has an environment that is not in this list, it will be marked as "Stadium" */
   customEnvironments: ["Highlands", "NewSnowCar"]
 }

--- a/config/Config.js
+++ b/config/Config.js
@@ -99,5 +99,7 @@ export default {
   /** When using `matchString()` util with `stripTrackmaniaFormatting = true`, values are cached to optimize performance */
   matchStringCacheSize: 10000,
   /** If haystack size exceeds this threshold `matchString()` will skip expensive haystack processing to optimize performance */
-  matchStringReduxModeThreshold: 5000
+  matchStringReduxModeThreshold: 5000,
+  /** Custom map environments. If a map has an environment that is not in this list, it will be marked as "Other" */
+  customEnvironments: ["Highlands", "NewSnowCar"]
 }

--- a/plugins/server_links/ServerLinks.ts
+++ b/plugins/server_links/ServerLinks.ts
@@ -91,7 +91,7 @@ async function refreshOtherServersData() {
     let newInfo: Partial<ServerInfo>
     try {
       newInfo = JSON.parse(file)
-    } catch(err) {
+    } catch (err) {
       continue
     }
     const infoObj = constructInfoObject(newInfo, e.name)

--- a/plugins/tmx/ui/TMXWindow.component.ts
+++ b/plugins/tmx/ui/TMXWindow.component.ts
@@ -70,19 +70,19 @@ class TMXWindow extends PopupWindow<number> {
       maps = [tm.jukebox.history?.[index + 2], tm.jukebox.history?.[index + 1], tm.jukebox.history?.[index]]
       TMXMaps = [tmx.history?.[index + 2], tmx.history?.[index + 1], tmx.history?.[index]]
       titles = [`${config.titles.previous} #${index + 3} `, `${config.titles.previous} #${index + 2} `,
-        `${config.titles.previous} #${index + 1} `]
+      `${config.titles.previous} #${index + 1} `]
     } else {
       const index = Math.ceil((page - (currentPage + 1)) * config.itemsPerPage) + 1
       maps = [tm.jukebox.queue?.[index], tm.jukebox.queue?.[index + 1], tm.jukebox.queue?.[index + 2]]
       TMXMaps = [tmx.queue?.[index], tmx.queue?.[index + 1], tmx.queue?.[index + 2]]
       titles = [`${config.titles.next} #${index + 1} `, `${config.titles.next} #${index + 2} `,
-        `${config.titles.next} #${index + 3} `]
+      `${config.titles.next} #${index + 3} `]
     }
     const m = maps.filter(a => a !== undefined).map(a => (a as any).id)
     const allRecords: Readonly<tm.Record[]> = [...tm.records.getFromHistory(...m), ...tm.records.local,
-      ...tm.records.getFromQueue(...m)]
-    .sort((a, b) => a.time - b.time)
-    .filter((a, i, arr) => arr.findIndex(b => b.login === a.login && a.map === b.map) === i)
+    ...tm.records.getFromQueue(...m)]
+      .sort((a, b) => a.time - b.time)
+      .filter((a, i, arr) => arr.findIndex(b => b.login === a.login && a.map === b.map) === i)
     const cell: GridCellFunction = (i, j, w, h) => {
       const map = maps[j]
       if (map === undefined) { return '' }
@@ -129,7 +129,7 @@ image="${image}" url="${url}" /> `
         config.iconWidth)}
 <frame posn="${width - (config.iconWidth + config.margin * 2)} 0 4" >
   ${icon(0, 0, config.icons.dedimania,
-        tm.utils.safeString(`dedimania.net/tmstats/?do=stat&Uid=${map.id}&Show=RECORDS`))}
+          tm.utils.safeString(`dedimania.net/tmstats/?do=stat&Uid=${map.id}&Show=RECORDS`))}
 </frame>`
     }
     return `${this.constructEntry(title, config.icons.header, width - (config.iconWidth + config.margin) * 3, height,
@@ -138,7 +138,7 @@ image="${image}" url="${url}" /> `
       ${icon(0, 0, config.icons.maniaExchange, tm.utils.fixProtocol(TMXMap.pageUrl))}
       ${icon(config.iconWidth + config.margin, 0, config.icons.downloadGreen, tm.utils.fixProtocol(TMXMap.downloadUrl))}
       ${icon((config.iconWidth + config.margin) * 2, 0, config.icons.dedimania,
-      tm.utils.safeString(`dedimania.net/tmstats/?do=stat&Uid=${map.id}&Show=RECORDS`))}
+        tm.utils.safeString(`dedimania.net/tmstats/?do=stat&Uid=${map.id}&Show=RECORDS`))}
     </frame>`
   }
 
@@ -149,10 +149,10 @@ image="${image}" url="${url}" /> `
       <frame posn="${iconWidth + config.margin * 2} ${-config.margin} 4">
         <quad posn="0 0 3" sizen="${width - (iconWidth + config.margin * 3)} ${height - config.margin * 2}" bgcolor="${config.gridBackground}"/>
         ${useCenteredText === true ?
-      centeredText(text, width - (iconWidth + config.margin * 3), height - config.margin * 2,
-        { textScale: config.textscale }) :
-      leftAlignedText(text, width - (iconWidth + config.margin * 3), height - config.margin * 2,
-        { textScale: config.textscale })}
+        centeredText(text, width - (iconWidth + config.margin * 3), height - config.margin * 2,
+          { textScale: config.textscale }) :
+        leftAlignedText(text, width - (iconWidth + config.margin * 3), height - config.margin * 2,
+          { textScale: config.textscale })}
       </frame>`
   }
 
@@ -191,11 +191,11 @@ image="${image}" url="${url}" /> `
     const timeCell: GridCellFunction = (i, j, w, h) => centeredText(
       records[i - 1] !== undefined ? tm.utils.getTimeString(records[i - 1]?.time) : config.defaultTime, w, h, options)
     const arr: (GridCellFunction | GridCellObject)[] = [(i, j, w, h) => centeredText('Lp.', w, h, options),
-      (i, j, w, h) => centeredText('Time', w, h, options), (i, j, w, h) => centeredText('Name', w, h, options)]
+    (i, j, w, h) => centeredText('Time', w, h, options), (i, j, w, h) => centeredText('Name', w, h, options)]
     for (let i = 0; i < count; i++) {
       arr.push(indexCell, timeCell, nameCell)
     }
-    const image = TMXMap === undefined ? config.noScreenshot[environment] :
+    const image = TMXMap === undefined ? (config.noScreenshot[environment as keyof typeof config.noScreenshot] ?? config.noScreenshot.Stadium) :
       tm.utils.safeString(TMXMap.thumbnailUrl + `&.jpeg`)
     return `<quad posn="${config.margin} ${-config.margin} 8" sizen="${config.screenshotWidth} ${height - config.margin * 2}" image="${image}"/>
       ${centeredText(config.notLoaded, config.screenshotWidth, height, {
@@ -216,7 +216,7 @@ image="${image}" url="${url}" /> `
       height, config.iconWidth)}
     <frame posn="${width - (config.authorTimeWidth + config.margin)} 0 4">
       ${this.constructEntry(tm.utils.getTimeString(map.authorTime), config.icons.authorTime,
-      config.authorTimeWidth + config.margin, height, config.iconWidth, true)}
+        config.authorTimeWidth + config.margin, height, config.iconWidth, true)}
     </frame>`
   }
 
@@ -236,19 +236,19 @@ image="${image}" url="${url}" /> `
     let awardsIcon = ic.awards.normal
     if (lbRating === 'Nadeo') { awardsIcon = ic.awards.nadeo } else if (lbRating === 'Classic') { awardsIcon = ic.awards.classic }
     const infos: [string, string][] = [[map.mood, ic.mood[map.mood.toLowerCase() as keyof typeof ic.mood]],
-      [tm.utils.formatDate(map.addDate, true), ic.addDate],
-      [map.voteRatio === -1 ? config.defaultText : map.voteRatio.toFixed(0), ic.voteRatio],
-      [map.copperPrice.toString(), ic.copperPrice], [map.environment, ic.environment],
-      [map?.checkpointsPerLap !== undefined ? `${map.checkpointsPerLap - 1} CPs` : config.defaultText,
-        ic.checkpointsAmount], [map.voteCount.toString(), ic.voteCount],
-      [(TMXMap?.awards?.toString() ?? map?.awards?.toString()) ?? config.defaultText, awardsIcon],
-      [TMXMap?.author === undefined ? config.defaultText :
-        (tm.utils.isMultibyte(TMXMap.author) ? '' : tm.utils.safeString(TMXMap.author)), ic.tmxAuthor],
-      [TMXMap !== undefined ? tm.utils.formatDate(TMXMap.lastUpdateDate, true) : config.defaultText, ic.buildDate],
-      [TMXMap?.style ?? config.defaultText, ic.style], [lbRating, lbIcon], [TMXMap?.difficulty ?? config.defaultText,
-        ic.difficulty[(TMXMap?.difficulty?.toLowerCase() as keyof typeof ic.difficulty) ?? 'beginner']],
-      [TMXMap?.routes ?? config.defaultText, ic.routes], [TMXMap?.type ?? config.defaultText, ic.type],
-      [TMXMap?.game ?? config.defaultText, ic.game]]
+    [tm.utils.formatDate(map.addDate, true), ic.addDate],
+    [map.voteRatio === -1 ? config.defaultText : map.voteRatio.toFixed(0), ic.voteRatio],
+    [map.copperPrice.toString(), ic.copperPrice], [map.environment, ic.environment],
+    [map?.checkpointsPerLap !== undefined ? `${map.checkpointsPerLap - 1} CPs` : config.defaultText,
+    ic.checkpointsAmount], [map.voteCount.toString(), ic.voteCount],
+    [(TMXMap?.awards?.toString() ?? map?.awards?.toString()) ?? config.defaultText, awardsIcon],
+    [TMXMap?.author === undefined ? config.defaultText :
+      (tm.utils.isMultibyte(TMXMap.author) ? '' : tm.utils.safeString(TMXMap.author)), ic.tmxAuthor],
+    [TMXMap !== undefined ? tm.utils.formatDate(TMXMap.lastUpdateDate, true) : config.defaultText, ic.buildDate],
+    [TMXMap?.style ?? config.defaultText, ic.style], [lbRating, lbIcon], [TMXMap?.difficulty ?? config.defaultText,
+    ic.difficulty[(TMXMap?.difficulty?.toLowerCase() as keyof typeof ic.difficulty) ?? 'beginner']],
+    [TMXMap?.routes ?? config.defaultText, ic.routes], [TMXMap?.type ?? config.defaultText, ic.type],
+    [TMXMap?.game ?? config.defaultText, ic.game]]
     const cell: GridCellFunction = (i, j, w, h) => {
       const index = (i * grid.columns) + j
       return `
@@ -272,8 +272,8 @@ image="${image}" url="${url}" /> `
     })
     const options = { textScale: config.recordTextScale }
     const arr: (GridCellFunction | GridCellObject)[] = [(i, j, w, h) => centeredText('Lp.', w, h, options),
-      (i, j, w, h) => centeredText('Time', w, h, options), (i, j, w, h) => centeredText('Name', w, h, options),
-      (i, j, w, h) => centeredText('Date', w, h, options), (i, j, w, h) => centeredText('Dl.', w, h, options)]
+    (i, j, w, h) => centeredText('Time', w, h, options), (i, j, w, h) => centeredText('Name', w, h, options),
+    (i, j, w, h) => centeredText('Date', w, h, options), (i, j, w, h) => centeredText('Dl.', w, h, options)]
     const indexCell: GridCellObject = {
       callback: (i, j, w, h) => centeredText(i.toString(), w, h, options),
       background: config.iconBackground

--- a/plugins/ui/UI.ts
+++ b/plugins/ui/UI.ts
@@ -43,7 +43,8 @@ const currentModIndex = {
   'Bay': 0,
   'Coast': 0,
   'Island': 0,
-  'Rally': 0
+  'Rally': 0,
+  ...tm.config.controller.customEnvironments.reduce((acc, env) => ({ ...acc, [env]: 0 }), {})
 }
 
 const loadMod = (): void => {
@@ -131,7 +132,7 @@ const events: tm.Listener[] = [{
 }, {
   event: 'EndMap',
   callback: async (): Promise<void> => {
-    currentModIndex[tm.maps.current.environment]++
+    currentModIndex[tm.maps.current.environment as keyof typeof currentModIndex]++
     loadMod()
   }
 }, {

--- a/src/Namespace.ts
+++ b/src/Namespace.ts
@@ -1,4 +1,4 @@
-export {}
+export { }
 declare global {
   /** Global Trakman object providing methods to interact with controller */
   namespace tm {
@@ -981,7 +981,7 @@ declare global {
     /** Server game mode ('TimeAttack', 'Rounds', 'Cup', 'Laps', 'Teams', 'Stunts') */
     export type GameMode = 'TimeAttack' | 'Rounds' | 'Cup' | 'Laps' | 'Teams' | 'Stunts'
     /** Map environment ('Stadium', 'Island', etc.) */
-    export type Environment = 'Stadium' | 'Island' | 'Desert' | 'Rally' | 'Bay' | 'Coast' | 'Snow'
+    export type Environment = string
     /** Map mood ('Sunrise', 'Night', etc.) */
     export type Mood = 'Sunrise' | 'Day' | 'Sunset' | 'Night'
     /** Server command data type */

--- a/src/TMXFetcher.ts
+++ b/src/TMXFetcher.ts
@@ -184,7 +184,7 @@ export abstract class TMXFetcher {
       tmxId = arg
       const url = `https://${prefix}.tm-exchange.com/api/tracks?${new URLSearchParams([['fields',
         `TrackId,TrackName,UId,AuthorTime,AuthorScore,GoldTarget,SilverTarget,BronzeTarget,Authors,UploadedAt,` + `UpdatedAt,PrimaryType,AuthorComments,Style,Routes,Difficulty,Environment,Car,Mood,Awards,Comments,Images`],
-        ['id', tmxId.toString()]])}`
+      ['id', tmxId.toString()]])}`
       const res = await fetch(url).catch((err: Error) => err)
       if (res instanceof Error) {
         Logger.warn(`Error while fetching map info from TMX (url: ${url}).`, res.message)
@@ -207,7 +207,7 @@ export abstract class TMXFetcher {
       for (const p of this.prefixes) { // Search for right prefix
         const url = `https://${p}.tm-exchange.com/api/tracks?${new URLSearchParams([['fields',
           `TrackId,TrackName,UId,AuthorTime,AuthorScore,GoldTarget,SilverTarget,BronzeTarget,Authors,UploadedAt,` + `UpdatedAt,PrimaryType,AuthorComments,Style,Routes,Difficulty,Environment,Car,Mood,Awards,Comments,Images`],
-          ['uid', arg.toString()]])}`
+        ['uid', arg.toString()]])}`
         const res = await fetch(url).catch((err: Error) => err)
         if (res instanceof Error || !res.ok) {
           continue
@@ -233,7 +233,7 @@ export abstract class TMXFetcher {
     let parsedData
     try {
       parsedData = this.parseMapInfoApiResponse(data, replays, this.prefixToSite(prefix), prefix)
-    } catch(ex) {
+    } catch (ex) {
       Logger.debug(`Tmx map info api parse error ${ex}`, `Map data: ${data}`, `Arg: ${arg}`, `Prefix: ${prefix}`)
       return new Error()
     }
@@ -252,7 +252,7 @@ export abstract class TMXFetcher {
   static async getReplays(tmxId: number, prefix: TMXPrefix): Promise<tm.TMXReplay[] | Error> {
     const url = `https://${prefix}.tm-exchange.com/api/replays?${new URLSearchParams(
       [['fields', 'ReplayTime,ReplayId,ReplayScore,Score,TrackAt,ReplayAt,User.UserId,User.Name'],
-        ['trackId', tmxId.toString()], ['best', '1'] // only get the best replay from each player
+      ['trackId', tmxId.toString()], ['best', '1'] // only get the best replay from each player
       ])}`
     const res = await fetch(url).catch((err: Error) => err)
     let data: any
@@ -303,13 +303,13 @@ export abstract class TMXFetcher {
   static async searchForMap(query?: string, author?: string, site: tm.TMXSite = this.packmaskSite,
     count: number = config.defaultTMXSearchLimit): Promise<Error | tm.TMXSearchResult[]> {
     const params: [string, string][] = [['count', count.toString()], ['name', (query ?? '').trim()],
-      ['author', (author ?? '').trim()]]
+    ['author', (author ?? '').trim()]]
     if (author === undefined) { params.pop() }
     if (query === undefined) { params.pop() }
     const prefix = this.siteToPrefix(site)
     const url = `https://${prefix}.tm-exchange.com/api/tracks?${new URLSearchParams([['fields',
       `TrackId,TrackName,UId,AuthorTime,AuthorScore,Authors,UploadedAt,` + `UpdatedAt,PrimaryType,AuthorComments,Style,Routes,Difficulty,Environment,Car,Mood,Awards,Comments,Images,TrackValue`],
-      ...params])}`
+    ...params])}`
     const res = await fetch(url).catch((err: Error) => err)
     if (res instanceof Error) {
       Logger.warn(`Error while searching for map on TMX (url: ${url}).`, res.message)
@@ -384,7 +384,7 @@ export abstract class TMXFetcher {
         uploadDate: new Date(e.UploadedAt),
         lastUpdateDate: new Date(e.UpdatedAt),
         type: this.mapTypes[e.PrimaryType as keyof typeof this.mapTypes],
-        environment: this.environments[e.Environment as keyof typeof this.environments],
+        environment: this.environments[e.Environment as keyof typeof this.environments] ?? "Stadium",
         mood: this.moods[e.Mood as keyof typeof this.moods],
         style: this.styles[e.Style as keyof typeof this.styles],
         routes: this.routes[e.Routes as keyof typeof this.routes],
@@ -418,7 +418,7 @@ export abstract class TMXFetcher {
       uploadDate: new Date(data.UploadedAt),
       lastUpdateDate: new Date(data.UpdatedAt),
       type: this.mapTypes[data.PrimaryType as keyof typeof this.mapTypes],
-      environment: this.environments[data.Environment as keyof typeof this.environments],
+      environment: this.environments[data.Environment as keyof typeof this.environments] ?? "Stadium",
       mood: this.moods[data.Mood as keyof typeof this.moods],
       style: this.styles[data.Style as keyof typeof this.styles],
       routes: this.routes[data.Routes as keyof typeof this.routes],

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -213,9 +213,9 @@ export const Utils = {
       Rally: 'Rally',
       Bay: 'Bay',
       Coast: 'Coast',
-      Snow: 'Alpine'
+      Snow: 'Alpine',
     }
-    return environmentMap[environment]
+    return environmentMap[environment] ?? environment
   },
 
   matchString,

--- a/src/database/MapRepository.ts
+++ b/src/database/MapRepository.ts
@@ -42,7 +42,8 @@ const environments = {
   Rally: 4,
   Bay: 5,
   Coast: 6,
-  Snow: 7
+  Snow: 7,
+  ...config.customEnvironments.map((name, i) => ({ [name]: i + 8 })).reduce((a, b) => ({ ...a, ...b }), {})
 }
 
 const mapIdsRepo = new MapIdsRepository()
@@ -74,11 +75,12 @@ export class MapRepository extends Repository {
     uids.forEach((map, i) => {
       if (map !== undefined) {
         values.push(
-          ([i, map.name.replaceAll('\n', ' '), map.fileName, map.author, environments[map.environment], moods[map.mood],
+          ([i, map.name.replaceAll('\n', ' '), map.fileName, map.author, environments[map.environment as keyof typeof environments] ?? environments["Stadium"],
+            moods[map.mood],
             map.bronzeTime, map.silverTime, map.goldTime, map.authorTime, map.copperPrice, map.isLapRace,
             map.defaultLapsAmount, map.checkpointsPerLap, map.addDate.toISOString(), map.leaderboardRating,
             map.awards]).map(a => a === undefined ? '\\N' : a.toString()
-          .replaceAll('\t', ' ').replaceAll('\\', '')).join('\t')) // ugly replace to prevent DB errors
+              .replaceAll('\t', ' ').replaceAll('\\', '')).join('\t')) // ugly replace to prevent DB errors
       }
     })
     const bulk = values.join('\n')
@@ -102,7 +104,7 @@ export class MapRepository extends Repository {
     const arr = maps.filter(a => ids.some(b => b.uid === a.id))
     if (arr.length !== maps.length) {
       Logger.error(`Failed to get ids for maps ${maps
-      .filter(a => !ids.some(b => b.uid === a.id)).join(', ')} while inserting into maps table`)
+        .filter(a => !ids.some(b => b.uid === a.id)).join(', ')} while inserting into maps table`)
     }
     if (arr.length === 0) { return }
     const query = `INSERT INTO maps(id, name, filename, author, environment, mood, 
@@ -111,7 +113,7 @@ export class MapRepository extends Repository {
       ids.length)} ON CONFLICT DO NOTHING`
     const values: any[] = []
     for (const [i, map] of arr.entries()) {
-      values.push(ids[i].id, map.name, map.fileName, map.author, environments[map.environment], moods[map.mood],
+      values.push(ids[i].id, map.name, map.fileName, map.author, environments[map.environment as keyof typeof environments] ?? environments["Stadium"], moods[map.mood],
         map.bronzeTime, map.silverTime, map.goldTime, map.authorTime, map.copperPrice, map.isLapRace,
         map.defaultLapsAmount, map.checkpointsPerLap, map.addDate, map.leaderboardRating, map.awards)
     }
@@ -358,7 +360,7 @@ export class MapRepository extends Repository {
       name: entry.name,
       fileName: entry.filename,
       author: entry.author,
-      environment: Object.entries(environments).find(a => a[1] === entry.environment)?.[0] as any,
+      environment: Object.entries(environments).find(a => a[1] === entry.environment)?.[0] as tm.Environment ?? 'Stadium',
       mood: Object.entries(moods).find(a => a[1] === entry.mood)?.[0] as any,
       bronzeTime: entry.bronze_time,
       silverTime: entry.silver_time,

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -89,7 +89,7 @@ export class MapService {
         map: a,
         rand: Math.random()
       }))
-      .sort((a, b): number => a.rand - b.rand).map(a => a.map)
+        .sort((a, b): number => a.rand - b.rand).map(a => a.map)
       return
     }
     const mapList: any[] | Error = await Client.call('GetChallengeList', [{ int: 5000 }, { int: 0 }])
@@ -139,7 +139,7 @@ export class MapService {
       map: a,
       rand: Math.random()
     }))
-    .sort((a, b): number => a.rand - b.rand).map(a => a.map)
+      .sort((a, b): number => a.rand - b.rand).map(a => a.map)
     await this.repo.splitAdd(mapsNotInDBObjects)
   }
 
@@ -651,7 +651,7 @@ export class MapService {
     } else {
       Logger.trace(`Map ${Utils.strip(
         this._queue[index].map.name)} by ${this._queue[index].map.author} has been removed from the ${jukebox ?
-        'jukebox' : 'queue'}`)
+          'jukebox' : 'queue'}`)
     }
     this._queue.splice(index, 1)
     this.fillQueue()
@@ -780,12 +780,14 @@ export class MapService {
     } else if (info.Environnement === 'Alpine') {
       info.Environnement = 'Snow'
     }
+    const validEnvs = ["Stadium", "Island", "Desert", "Rally", "Bay", "Coast", "Snow"].concat(config.customEnvironments)
+
     return {
       id: info.UId,
       name: info.Name,
       fileName: info.FileName,
       author: info.Author,
-      environment: info.Environnement,
+      environment: validEnvs.includes(info.Environnement) ? info.Environnement : 'Stadium',
       mood: info.Mood,
       bronzeTime: info.BronzeTime,
       silverTime: info.SilverTime,


### PR DESCRIPTION
Highlands and other custom environments make the server crash because it handles environments as an enum. I added `customEnvironments` config variable which can be used to extend the enum (default value is  `["Highlands", "NewSnowCar"]`) and made the code fallback to `Stadium` when it encounters an unknown environment. I expect some UI bugs to happen, but that's better than the controller just crashing right after adding such maps.