### PR TITLE
Add config overriding and loading of external plugins

### DIFF
--- a/config/Config.js
+++ b/config/Config.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../src/ConfigLoader.js"
+const defaultConfig = {
   /**
    * Manual chat routing is needed for chat utilities such as custom brackets or finish counter.
    * Enabling it makes the chat a bit slower, as all input has to go through the controller first.
@@ -100,6 +101,13 @@ export default {
   matchStringCacheSize: 10000,
   /** If haystack size exceeds this threshold `matchString()` will skip expensive haystack processing to optimize performance */
   matchStringReduxModeThreshold: 5000,
+  /**
+   * Additional plugin module files to load at startup.
+   * Paths are resolved from the Trakman working directory unless absolute.
+   */
+  externalPlugins: [],
   /** Custom map environments. If a map has an environment that is not in this list, it will be marked as "Stadium" */
   customEnvironments: ["Highlands", "NewSnowCar"]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/config/Messages.js
+++ b/config/Messages.js
@@ -1,8 +1,9 @@
+import { loadConfig } from "../src/ConfigLoader.js"
 import prefixes from './PrefixesAndPalette.js'
 
 const p = prefixes.palette
 
-export default {
+const defaultConfig = {
   /** Message sent to the player attempting to use a command they do not have the permission for */
   noPermission: `${p.error} You have no permission to use this command.`,
   /** Message sent to the muted player attempting to use a command that is disabled for muted players */
@@ -26,3 +27,5 @@ export default {
   /** Message sent to the player if the specified login is not found in the database */
   unknownPlayer: `${p.error}Unknown player ${p.highlight}#{name}${p.error}.`
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/config/PrefixesAndPalette.js
+++ b/config/PrefixesAndPalette.js
@@ -1,51 +1,59 @@
 import colours from '../src/data/Colours.js'
+import { loadConfig } from "../src/ConfigLoader.js"
 
-export const prefixes = {
+const defaultConfig = {
+  prefixes: {
   /** Default chat message format when manual chat routing is enabled. This can be overwritten by tm.chat.setMessageStyle() method */
-  manualChatRoutingMessageStyle: `$g[#{name}$z$s$g] `,
+    manualChatRoutingMessageStyle: `$g[#{name}$z$s$g] `,
   /** Characters with which every message sent to individual players will be prefixed (e.g. ChatSendServerMessageToLogin) */
-  serverToPlayer: `${colours.yellow}» `,
+    serverToPlayer: `${colours.yellow}» `,
   /** Characters with which every message sent in public will be prefixed (e.g. ChatSendServerMessage) */
-  serverToAll: `${colours.yellow}»» `
+    serverToAll: `${colours.yellow}»» `
+  },
+
+  /** Controller messages palette object */
+  /** All admin commands */
+  palette: {
+    admin: colours.erin,
+  /** Dedi record messages */
+    dedirecord: colours.darkpastelgreen,
+  /** Dedi misc messages */
+    dedimessage: colours.kellygreen,
+  /** Donation messages */
+    donation: colours.brilliantrose,
+  /** Error messages */
+    error: colours.red,
+  /** General highlighting colour */
+    highlight: colours.white,
+  /** Karma messages */
+    karma: colours.greenyellow,
+  /** Server messages */
+    servermsg: colours.erin,
+  /** Misc messages */
+    message: colours.lightseagreen,
+  /** Rank highlighting colour */
+    rank: colours.icterine,
+  /** Record messages */
+    record: colours.erin,
+  /** Server message prefix colour */
+    server: colours.yellow,
+  /** Voting messages */
+    vote: colours.chartreuse,
+  /** Green */
+    green: 'af4',
+  /** Red */
+    red: 'e22',
+  /** Yellow */
+    yellow: 'fc1',
+  /** Purple */
+    purple: '4af'
+  }
 }
 
-/** Controller messages palette object */
-export const palette = {
-  /** All admin commands */
-  admin: colours.erin,
-  /** Dedi record messages */
-  dedirecord: colours.darkpastelgreen,
-  /** Dedi misc messages */
-  dedimessage: colours.kellygreen,
-  /** Donation messages */
-  donation: colours.brilliantrose,
-  /** Error messages */
-  error: colours.red,
-  /** General highlighting colour */
-  highlight: colours.white,
-  /** Karma messages */
-  karma: colours.greenyellow,
-  /** Server messages */
-  servermsg: colours.erin,
-  /** Misc messages */
-  message: colours.lightseagreen,
-  /** Rank highlighting colour */
-  rank: colours.icterine,
-  /** Record messages */
-  record: colours.erin,
-  /** Server message prefix colour */
-  server: colours.yellow,
-  /** Voting messages */
-  vote: colours.chartreuse,
-  /** Green */
-  green: 'af4',
-  /** Red */
-  red: 'e22',
-  /** Yellow */
-  yellow: 'fc1',
-  /** Purple */
-  purple: '4af'
-}
+const loadedConfig = await loadConfig(defaultConfig, import.meta.url)
+
+export const prefixes = loadedConfig.prefixes
+export const palette = loadedConfig.palette
 
 export default {
   prefixes,

--- a/config/Titles.js
+++ b/config/Titles.js
@@ -1,20 +1,30 @@
+import { loadConfig } from "../src/ConfigLoader.js"
+
 // Player titles are assigned in order: logins, nations, privileges
-export const titles = {
+const defaultConfig = {
+  titles: {
   /** Pairs of login and title where the title is assigned to the specified login */
-  logins: {
-    'login': 'title'
-  },
+    logins: {
+      'login': 'title'
+    },
   /** Pairs of country and title where the title is assigned to every player from the specified country (country codes work too) */
-  countries: {
-    'country': 'title',
-    'CODE': 'title' // country code
-  },
+    countries: {
+      'country': 'title',
+      'CODE': 'title' // country code
+    },
   /** Pairs of privilege and title where the title is assigned to every player with the specified privilege level */
-  privileges: {
-    0: 'Player',
-    1: 'Operator',
-    2: 'Admin',
-    3: 'Masteradmin',
-    4: 'Server Owner'
+    privileges: {
+      0: 'Player',
+      1: 'Operator',
+      2: 'Admin',
+      3: 'Masteradmin',
+      4: 'Server Owner'
+    }
   }
 }
+
+const loadedConfig = await loadConfig(defaultConfig, import.meta.url)
+
+export const titles = loadedConfig.titles
+
+export default loadedConfig

--- a/plugins/actions/Config.js
+++ b/plugins/actions/Config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 import icons from '../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   noPermission: `${p.error}You have no permission to perform this action.`,
   addVote: {
     voteTexts: {
@@ -139,3 +140,5 @@ export default {
     public: true
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/betting/Config.js
+++ b/plugins/betting/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   // If false plugin cant be activated
   isEnabled: false, // This can be changed using an ingame command
   isActive: false,
@@ -46,3 +47,5 @@ export default {
     alreadyNotActive: `${p.error}Betting plugin is already disabled.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/betting/ui/BetInfoWidget.config.js
+++ b/plugins/betting/ui/BetInfoWidget.config.js
@@ -1,6 +1,8 @@
-import { icons, raceConfig } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import icons from '../../ui/config/Icons.js'
+import raceConfig from '../../ui/config/RaceUi.js'
 
-export default {
+const defaultConfig = {
   posX: raceConfig.rightPosition,
   side: true, // If true overrides posY prop and places the widget as last component
   placeAsLastComponent: true,
@@ -14,3 +16,5 @@ export default {
   topBorder: raceConfig.topBorder, // used for Y positioning
   marginBig: raceConfig.marginBig
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/betting/ui/BetPlaceWindow.config.js
+++ b/plugins/betting/ui/BetPlaceWindow.config.js
@@ -1,9 +1,11 @@
-import { raceConfig, StaticHeader } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import raceConfig from '../../ui/config/RaceUi.js'
+import StaticHeader from '../../ui/utils/StaticHeader.js'
 
 const p = tm.utils.palette
 
 const width = 10
-export default {
+const defaultConfig = {
   posX: raceConfig.rightPosition - (width + raceConfig.marginBig),
   headerText: `Bet`, // To position the widget next to side ui widgets set these properties and keep staticPos props null
   relativePos: {
@@ -43,3 +45,5 @@ export default {
   topBorder: raceConfig.topBorder, // used for Y positioning
   marginBig: raceConfig.marginBig
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/chat_routing_additions/CustomBracket.config.js
+++ b/plugins/chat_routing_additions/CustomBracket.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   isEnabled: true,
   brackets: [{
     logins: ['login1'],
@@ -13,3 +14,5 @@ export default {
   }], // If there is another function modifying chat nickname with higher importance it will overwrite this one
   importance: 1
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/chat_routing_additions/FinishCounter.config.js
+++ b/plugins/chat_routing_additions/FinishCounter.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   isEnabled: false,
   colours: [{
     amount: 0,
@@ -20,3 +21,5 @@ export default {
   } // Gradient
   ]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/chat_routing_additions/UrlFixer.config.js
+++ b/plugins/chat_routing_additions/UrlFixer.config.js
@@ -1,5 +1,8 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: true,
   matchRegex: /(http:\/\/|https:\/\/)/gi,
   importance: 1
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/checkpoint_records/Config.js
+++ b/plugins/checkpoint_records/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 import { palette as p } from '../../config/PrefixesAndPalette.js'
 
-export default {
+const defaultConfig = {
   isEnabled: true, // Using DB client makes the plugin a bit faster due to high amount of database queries
   // Program can run only run limited amount of clients, the process will hang otherwise
   useDBClient: true,
@@ -24,3 +25,5 @@ export default {
     }
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/checkpoint_records/ui/CheckpointRecords.config.js
+++ b/plugins/checkpoint_records/ui/CheckpointRecords.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: ' Checkpoint Records ',
   icon: icons.clock,
   entries: 14,
@@ -48,3 +50,5 @@ export default {
   noTimeText: '--:--.-',
   stuntsNoTimeText: '--'
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/AdminCommands.config.js
+++ b/plugins/commands/config/AdminCommands.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 const p = tm.utils.palette
 const priv = tm.admin.privileges
 
-export default {
+const defaultConfig = {
   kick: {
     privilege: priv.kick,
     aliases: ['k', 'kick'],
@@ -102,3 +103,5 @@ export default {
     public: true
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/ChatCommands.config.js
+++ b/plugins/commands/config/ChatCommands.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 const p = tm.utils.palette
 const prefix = `$i` // Prefix all "fake" player messages with this (eg. $i, $t, etc)
 
-export default {
+const defaultConfig = {
   defaultValue: `everyone`, // This value will be used for the name if you don't specify anything in e.g. /hi
   hi: {
     text: `$g[#{nickname}$z$s$g] ${prefix}Hello, #{name}$g!`,
@@ -182,3 +183,5 @@ export default {
     help: `Check the amount of coppers the server account currently has.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/GameCommands.config.js
+++ b/plugins/commands/config/GameCommands.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   setgamemode: {
     text: `${p.admin}#{title} ${p.highlight}#{adminName} ${p.admin}has set the gamemode to ${p.highlight}#{mode}${p.admin}.`,
     public: true,
@@ -117,3 +118,5 @@ export default {
     help: `Set whether checkpoint respawning is enabled.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/JukeboxCommands.config.js
+++ b/plugins/commands/config/JukeboxCommands.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   dropjukebox: {
     text: `${p.admin}#{title} ${p.highlight}#{adminName} ${p.admin}has removed ${p.highlight}#{name} ${p.admin}from the queue.`,
     error: `${p.error}No such index in the queue.`,
@@ -32,3 +33,5 @@ export default {
     help: `Clear the map history.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/KarmaCommands.config.js
+++ b/plugins/commands/config/KarmaCommands.config.js
@@ -1,4 +1,7 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   aliases: ['+++', '++', '+', '-', '--', '---'], // DONT TOUCH THIS OR YOU DIE
   help: `Vote for a map.`
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/MapCommands.config.js
+++ b/plugins/commands/config/MapCommands.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   add: {
     privilege: tm.config.controller.privileges.addMap,
     aliases: ['add', 'am', 'addmap'],
@@ -56,3 +57,5 @@ export default {
     help: `Add a map from TMX.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/PrivilegesCommands.config.js
+++ b/plugins/commands/config/PrivilegesCommands.config.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   masteradmin: {
     public: true,
     privilege: 4,
@@ -24,3 +25,5 @@ export default {
     help: `Set player privilege to None (0).`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/RaceCommands.config.js
+++ b/plugins/commands/config/RaceCommands.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   skip: {
     text: `${p.admin}#{title} ${p.highlight}#{adminName} ${p.admin}has skipped the ongoing map.`,
     public: true,
@@ -46,3 +47,5 @@ export default {
     help: `Force a player into the specified team.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/RecordsCommands.config.js
+++ b/plugins/commands/config/RecordsCommands.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   delrec: {
     text: `${p.admin}#{title} ${p.highlight}#{adminName} ${p.admin}has removed the record of ${p.highlight}#{nickname} ${p.admin}on the ongoing map.`,
     noPlayerRecord: `${p.error}Player #{login} does not have a record on this map.`,
@@ -18,3 +19,5 @@ export default {
     help: `Remove all records on the ongoing map.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/commands/config/ServerCommands.config.js
+++ b/plugins/commands/config/ServerCommands.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   timelimit: {
     set: `${p.admin}#{title} ${p.highlight}#{adminName} ${p.admin}has set the remaining time to ${p.highlight}#{time}${p.admin}.`,
     notDynamic: `${p.error}Dynamic timer is disabled.`,
@@ -178,3 +179,5 @@ export default {
     help: `Execute a dedicated server method. Params need to be specified in a valid json format or in "" for strings.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/dedimania/Config.js
+++ b/plugins/dedimania/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   isEnabled: true, // Maximum amount of fetched records
   // (Dedimania normally stores 30, there are exceptions such as Nadeo maps with 50-80 records)
   dediCount: 30,
@@ -11,3 +12,5 @@ export default {
   updateInterval: 240, // Interval for Dedimania server update, in seconds (recommended to be kept between 2-5 minutes)
   modifiedLapsMessage: `${p.dedimessage}Dedimania records will be sent in ${p.highlight}Time Attack` + ` ${p.dedimessage}instead of ${p.highlight}Rounds ${p.dedimessage}mode due to modified lap amount.`
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/dedimania/ui/DediCps.config.js
+++ b/plugins/dedimania/ui/DediCps.config.js
@@ -1,8 +1,10 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   entries: 15,
   cpsOnFirstPage: 10,
   icon: icons.chartDedi,
@@ -43,3 +45,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/dedimania/ui/DediSectors.config.js
+++ b/plugins/dedimania/ui/DediSectors.config.js
@@ -1,8 +1,10 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   entries: 15,
   cpsOnFirstPage: 10,
   icon: icons.chartDedi,
@@ -43,3 +45,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/donations/Config.js
+++ b/plugins/donations/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   paymentFail: `${p.error}Failed to process payment.`,
   paymentSuccess: `${p.highlight}#{nickname}${p.donation} ` + `donated ${p.highlight}#{amount}C${p.donation} to the server.`,
   minimalAmount: 50,
@@ -11,3 +12,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/dynamic_time_limit/Config.js
+++ b/plugins/dynamic_time_limit/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   // If false plugin cant be activated
   isEnabled: true,
   // This can be changed using an ingame command
@@ -33,3 +34,5 @@ export default {
     alreadyDisabled: `${p.error}Dynamic time limit is already disabled for the next map.`
   },
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/freezone/Config.js
+++ b/plugins/freezone/Config.js
@@ -1,6 +1,9 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: false, // Manialive hash, static value that never changes
   manialiveHash: '6f116833b419fe7cb9c912fdaefb774845f60e79', // Last Manialive (for TMF at least) version release
   manialiveVersion: 239, // Freezone Manialive URL (aka Trackmania Webservices)
   manialiveUrl: 'ws.trackmania.com'
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/info_messages/Config.js
+++ b/plugins/info_messages/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   isEnabled: true, // All the info messages will be prefixed with this text
   messagePrefix: `${p.record}[${p.highlight}INFO${p.record}]`, // Default formatting for the info messages
   // That is put inbetween the prefix and the message
@@ -28,3 +29,5 @@ export default {
   sendOnInterval: false, // Message sending interval
   messageInterval: 120 // Seconds
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/live_checkpoints/Config.js
+++ b/plugins/live_checkpoints/Config.js
@@ -1,3 +1,6 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: false
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/live_checkpoints/ui/LiveCpsRanking.config.js
+++ b/plugins/live_checkpoints/ui/LiveCpsRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import cfg from '../../ui/config/RaceUi.js'
 import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 6,
   entryHeight: 2.15,
   width: cfg.width,
@@ -14,3 +15,5 @@ export default {
   hidePanel: true,
   maxRecordsAmount: 3000 // If more records than this get driven in one round the click listener will break
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/maniakarma/Config.js
+++ b/plugins/maniakarma/Config.js
@@ -1,4 +1,7 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: true,
   reconnectTimeout: 300 //seconds
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/maplist/Config.js
+++ b/plugins/maplist/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   cacheSize: 10, // Max number of map arrays stored in cache
   added: `${p.highlight}#{nickname} ${p.vote}has added ${p.highlight}#{map}${p.vote} to the queue.`,
   noPermission: `${p.error}You can't add more than one map to the queue.`,
@@ -14,3 +15,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/maplist/ui/Maplist.config.js
+++ b/plugins/maplist/ui/Maplist.config.js
@@ -1,8 +1,10 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   title: 'Map List',
   icon: icons.mapList,
   textScale: 1,
@@ -85,3 +87,5 @@ export default {
     }
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/messages/Config.js
+++ b/plugins/messages/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   // Special message on every win multiple of this
   specialWin: 50,
   startup: {
@@ -81,3 +82,5 @@ export default {
     public: true
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/music/Config.js
+++ b/plugins/music/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   isEnabled: false,
   songListPath: './plugins/music/SongList.js', // Needed for updates on song add/remove
   overrideMapMusic: true, // If song is in history it can't be requeued without force queue privileges
@@ -43,3 +44,5 @@ export default {
     help: 'Open song list.'
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/music/ui/MusicWidget.config.js
+++ b/plugins/music/ui/MusicWidget.config.js
@@ -1,6 +1,8 @@
-import { icons, raceConfig as cfg } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import icons from '../../ui/config/Icons.js'
+import cfg from '../../ui/config/RaceUi.js'
 
-export default {
+const defaultConfig = {
   height: 7,
   title: 'Current Song',
   icon: icons.music,
@@ -20,3 +22,5 @@ export default {
   iconWidth: 1.7,
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/music/ui/SongList.config.js
+++ b/plugins/music/ui/SongList.config.js
@@ -1,8 +1,9 @@
-import { icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import icons from '../../ui/config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   title: ' Song List ',
   icon: icons.musicList,
   iconWidth: 2,
@@ -23,3 +24,5 @@ export default {
     headerBackground: '333C'
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/sector_records/Config.js
+++ b/plugins/sector_records/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 import { palette as p } from '../../config/PrefixesAndPalette.js'
 
-export default {
+const defaultConfig = {
   isEnabled: true, // Using DB client makes the plugin a bit faster due to high amount of database queries
   // If too many plugins are using DB clients the process might hang
   useDBClient: true,
@@ -24,3 +25,5 @@ export default {
     }
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/sector_records/ui/SectorRecords.config.js
+++ b/plugins/sector_records/ui/SectorRecords.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: ' Sector Records ',
   icon: icons.clock,
   entries: 13,
@@ -53,3 +55,5 @@ export default {
   noTimeText: '--:--.-',
   stuntsNoTimeText: '--'
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/server_links/Config.js
+++ b/plugins/server_links/Config.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: false, // http server can be used to connect servers running on different computers
   useHttpServer: false,
   httpAddress: '127.0.0.1',
@@ -16,3 +17,5 @@ export default {
   }],
   noDataText: '--'
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/server_links/ui/ServerLinks.config.js
+++ b/plugins/server_links/ui/ServerLinks.config.js
@@ -1,6 +1,8 @@
-import { icons, raceConfig as cfg } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import icons from '../../ui/config/Icons.js'
+import cfg from '../../ui/config/RaceUi.js'
 
-export default {
+const defaultConfig = {
   height: 33,
   width: cfg.width,
   title: 'Linked Servers',
@@ -32,3 +34,5 @@ export default {
   iconWidth: 1.7,
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/skip_endscreen/Config.js
+++ b/plugins/skip_endscreen/Config.js
@@ -1,4 +1,7 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: false, // For how long to wait before forcing everybody into specmode (in seconds)
   waitTime: 5
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/stats/Config.js
+++ b/plugins/stats/Config.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   winsCount: 100000,
   visitsCount: 100000,
   averagesCount: 100000,
@@ -9,3 +10,5 @@ export default {
   sumsCount: 100000, // Playtimes are updated on endmap and on this interval (default 10 minutes)
   playtimesUpdateInterval: 1000 * 60 * 10
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/stats/ui/TopDonations.config.js
+++ b/plugins/stats/ui/TopDonations.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Top Donations',
   icon: icons.cash,
   gridColumns: [0.8, 4, 3, 3, 0.8, 4, 3, 3],
@@ -40,3 +42,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/stats/ui/TopPlaytimes.config.js
+++ b/plugins/stats/ui/TopPlaytimes.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Top Playtimes',
   icon: icons.clockList,
   gridColumns: [0.8, 4, 3, 3, 0.8, 4, 3, 3],
@@ -40,3 +42,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/stats/ui/TopRanks.config.js
+++ b/plugins/stats/ui/TopRanks.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Top Ranks',
   icon: icons.chartLocal,
   gridColumns: [0.8, 4, 3, 3, 0.8, 4, 3, 3],
@@ -41,3 +43,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/stats/ui/TopRecords.config.js
+++ b/plugins/stats/ui/TopRecords.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Top Records',
   icon: icons.stats,
   gridColumns: [0.8, 4, 3, 3, 0.8, 4, 3, 3],
@@ -40,3 +42,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/stats/ui/TopSums.config.js
+++ b/plugins/stats/ui/TopSums.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Top Sums',
   icon: icons.stats,
   gridColumns: [0.8, 4, 3, 1, 1, 1, 1.3, 0.8, 4, 3, 1, 1, 1, 1.3],
@@ -46,3 +48,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/stats/ui/TopVisits.config.js
+++ b/plugins/stats/ui/TopVisits.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Top Visits',
   icon: icons.stats,
   gridColumns: [0.8, 4, 3, 3, 0.8, 4, 3, 3],
@@ -40,3 +42,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/stats/ui/TopVotes.config.js
+++ b/plugins/stats/ui/TopVotes.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Top Votes',
   icon: icons.karmaStats,
   gridColumns: [0.8, 4, 3, 3, 0.8, 4, 3, 3],
@@ -40,3 +42,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/stats/ui/TopWins.config.js
+++ b/plugins/stats/ui/TopWins.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Top Wins',
   icon: icons.stats,
   gridColumns: [0.8, 4, 3, 3, 0.8, 4, 3, 3],
@@ -40,3 +42,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/tmx/Config.js
+++ b/plugins/tmx/Config.js
@@ -1,5 +1,8 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: true,
   queueCount: 4,
   historyCount: 4
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/tmx/ui/TMXWindow.config.js
+++ b/plugins/tmx/ui/TMXWindow.config.js
@@ -1,6 +1,8 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
-export default {
+const defaultConfig = {
   icon: icons.ongoingMap,
   title: 'Map Info',
   navbar: [{
@@ -94,3 +96,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/Buttons.js
+++ b/plugins/ui/config/Buttons.js
@@ -1,3 +1,4 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from './Icons.js'
 import raceUi from './RaceUi.js'
 import resultUi from './ResultUi.js'
@@ -33,7 +34,7 @@ const p = tm.utils.palette
  * - text2PositionOffset (num) - Position offset of text2, makes the text go lower
  */
 
-export default {
+const defaultConfig = {
   /**
    * RaceUi icons
    */
@@ -81,3 +82,5 @@ export default {
     text2PositionOffset: 1.75
   }]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/ComponentIds.js
+++ b/plugins/ui/config/ComponentIds.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   PopupWindow: 0,
   rank: 40,
   timerResult: 60,
@@ -86,3 +87,5 @@ export default {
   liveCpsRanking: 550000, // needs 3.1 mil ids
   mapList: 10000000
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/CustomUi.js
+++ b/plugins/ui/config/CustomUi.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   notice: false,
   challengeInfo: false,
   netInfo: true,
@@ -8,3 +9,5 @@ export default {
   scoreTable: true,
   global: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/FlagIcons.js
+++ b/plugins/ui/config/FlagIcons.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   'ALG': 'https://trakman.ptrk.eu/icons/ALG.png',
   'ANG': 'https://trakman.ptrk.eu/icons/ANG.png',
   'ARG': 'https://trakman.ptrk.eu/icons/ARG.png',
@@ -92,3 +93,5 @@ export default {
   'VEN': 'https://trakman.ptrk.eu/icons/VEN.png',
   'VIE': 'https://trakman.ptrk.eu/icons/VIE.png'
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/Icons.js
+++ b/plugins/ui/config/Icons.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   clock: 'https://trakman.ptrk.eu/icons/Clock.png',
   close: 'https://trakman.ptrk.eu/icons/Close.png',
   closeHover: 'https://trakman.ptrk.eu/icons/CloseHover.png',
@@ -177,3 +178,5 @@ export default {
       this.pageLeftHover, this.pageRight, this.pageRightHover]
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/Mod.js
+++ b/plugins/ui/config/Mod.js
@@ -1,4 +1,5 @@
-export default // Environments are Stadium, Desert, Snow, Bay, Coast, Island, Rally
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = // Environments are Stadium, Desert, Snow, Bay, Coast, Island, Rally
 // If random order is disabled, mods array will be applied in order
 [{
   environment: 'Stadium',
@@ -29,3 +30,5 @@ export default // Environments are Stadium, Desert, Snow, Bay, Coast, Island, Ra
   modLinks: [`https://trakman.ptrk.eu/TrakmanMod.zip`],
   randomOrder: true
 }]
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/PopupWindow.js
+++ b/plugins/ui/config/PopupWindow.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   headerBg: '000C',
   bg: '000C',
   margin: 0.15,
@@ -10,3 +11,5 @@ export default {
   headerPageWidth: 10,
   textScale: 1
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/RaceUi.js
+++ b/plugins/ui/config/RaceUi.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   reduxModeEnablePlayerAmount: 20,
   reduxModeDisablePlayerAmount: 18,
   margin: 0.15,
@@ -38,3 +39,5 @@ export default {
   stuntsLeftSideOrder: ['ButtonsWidget', 'RankWidget', 'KarmaWidget', 'TMXRanking', 'UltiRanking', 'AdminPanel'],
   stuntsOtherComponents: ['BestCps', 'BestFinishes', 'CpCounter']
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/ResultUi.js
+++ b/plugins/ui/config/ResultUi.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   margin: 0.15,
   marginBig: 0.27,
   format: '$s',
@@ -16,3 +17,5 @@ export default {
     'RoundAveragesRanking', 'AdminPanelResult'],
   otherComponents: ['DonatorsRanking', 'MostRecordsRanking', 'PlaytimeRanking', 'WinnersRanking', 'BannerWidget']
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/config/UtilIds.js
+++ b/plugins/ui/config/UtilIds.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   PopupWindow: {
     open: 0,
     close: 1
@@ -25,3 +26,5 @@ export default {
   F7: 17,
   buttons: 18
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/Changelog.config.js
+++ b/plugins/ui/dynamic_components/Changelog.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import ids from '../config/ComponentIds.js'
 import icons from '../config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Changelog',
   icon: icons.codeBranch,
   navbar: [{
@@ -22,3 +23,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/Chatlog.config.js
+++ b/plugins/ui/dynamic_components/Chatlog.config.js
@@ -1,8 +1,9 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   title: ' Chat Log ',
   kickPrivilege: 1,
   forceSpecPrivilege: 1,
@@ -26,3 +27,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/Commandlist.config.js
+++ b/plugins/ui/dynamic_components/Commandlist.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import ids from '../config/ComponentIds.js'
 import icons from '../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   title: 'Command List',
   entries: 15,
   icon: icons.infoList,
@@ -48,3 +49,5 @@ export default {
   noMatchesMessage: `${p.error}Nothing found for ${p.highlight}#{query}${p.error}.`,
   aliasSearch: true // Whether to search for alias on query
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/PlayerStats.config.js
+++ b/plugins/ui/dynamic_components/PlayerStats.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import ids from '../config/ComponentIds.js'
 import icons from '../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   width: 60,
   title: `Personal Stats`,
   icon: icons.person,
@@ -30,3 +31,5 @@ export default {
     error: `${p.error}There's no information about this player in the database.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/ServerInfo.config.js
+++ b/plugins/ui/dynamic_components/ServerInfo.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import ids from '../config/ComponentIds.js'
 import icons from '../config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: `Server Overview`,
   icon: icons.trakman,
   navbar: [{
@@ -29,3 +30,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/TMXDetailsWindow.config.js
+++ b/plugins/ui/dynamic_components/TMXDetailsWindow.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 import ids from '../config/ComponentIds.js'
 
-export default {
+const defaultConfig = {
   title: 'TMX Detailed Info',
   icon: icons.maniaExchange,
   margin: 0.15,
@@ -94,3 +95,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/TMXSearchWindow.config.js
+++ b/plugins/ui/dynamic_components/TMXSearchWindow.config.js
@@ -1,8 +1,9 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   title: 'TMX Search Result',
   addPrivilege: tm.config.controller.privileges.addMap,
   icon: icons.mapList,
@@ -51,3 +52,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/WarnWindow.config.js
+++ b/plugins/ui/dynamic_components/WarnWindow.config.js
@@ -1,8 +1,9 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   width: 60,
   height: 40,
   padding: 2.5,
@@ -28,3 +29,5 @@ export default {
     privilege: 2
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/admin_lists/Adminlist.config.js
+++ b/plugins/ui/dynamic_components/admin_lists/Adminlist.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import ids from '../../config/ComponentIds.js'
 import icons from '../../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   title: ' Server Admins ',
   icon: icons.playerList,
   width: 65,
@@ -40,3 +41,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/admin_lists/Masteradminlist.config.js
+++ b/plugins/ui/dynamic_components/admin_lists/Masteradminlist.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import ids from '../../config/ComponentIds.js'
 import icons from '../../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   title: ' Server Masteradmins ',
   icon: icons.playerList,
   width: 65,
@@ -40,3 +41,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/admin_lists/Operatorlist.config.js
+++ b/plugins/ui/dynamic_components/admin_lists/Operatorlist.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import ids from '../../config/ComponentIds.js'
 import icons from '../../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   title: ' Server Operators ',
   icon: icons.playerList,
   width: 65,
@@ -40,3 +41,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/admin_windows/Banlist.config.js
+++ b/plugins/ui/dynamic_components/admin_windows/Banlist.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import ids from '../../config/ComponentIds.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   privilege: tm.config.controller.privileges.ban,
   title: ' Banned Players ',
   icon: icons.banlist,
@@ -40,3 +41,5 @@ export default {
     privilege: tm.config.controller.privileges.ban // literally useless
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/admin_windows/Blacklist.config.js
+++ b/plugins/ui/dynamic_components/admin_windows/Blacklist.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import ids from '../../config/ComponentIds.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   privilege: tm.config.controller.privileges.blacklist,
   title: ' Blacklisted Players ',
   icon: icons.blacklist,
@@ -40,3 +41,5 @@ export default {
     privilege: tm.config.controller.privileges.blacklist // literally useless
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/admin_windows/Guestlist.config.js
+++ b/plugins/ui/dynamic_components/admin_windows/Guestlist.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import ids from '../../config/ComponentIds.js'
 import icons from '../../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   privilege: tm.config.controller.privileges.addGuest,
   title: ' Guests ',
   icon: icons.guestlist,
@@ -43,3 +44,5 @@ export default {
     privilege: tm.config.controller.privileges.addGuest
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/admin_windows/Mutelist.config.js
+++ b/plugins/ui/dynamic_components/admin_windows/Mutelist.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import ids from '../../config/ComponentIds.js'
 import icons from '../../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   privilege: tm.config.controller.privileges.mute,
   title: ' Muted Players ',
   icon: icons.mutelist,
@@ -43,3 +44,5 @@ export default {
     privilege: tm.config.controller.privileges.mute
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/admin_windows/Playerlist.config.js
+++ b/plugins/ui/dynamic_components/admin_windows/Playerlist.config.js
@@ -1,10 +1,11 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import icons from '../../config/Icons.js'
 import ids from '../../config/ComponentIds.js'
 
 const p = tm.utils.palette
 const priv = tm.admin.privileges
 
-export default {
+const defaultConfig = {
   title: ' Players ',
   kickPrivilege: priv.kick,
   forceSpecPrivilege: priv.forceSpectator,
@@ -74,3 +75,5 @@ export default {
     privilege: 1
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/checkpoint_windows/LiveCps.config.js
+++ b/plugins/ui/dynamic_components/checkpoint_windows/LiveCps.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import icons from '../../config/Icons.js'
 import ids from '../../config/ComponentIds.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   entries: 15,
   cpsOnFirstPage: 10,
   icon: icons.chartLocal,
@@ -57,3 +58,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/checkpoint_windows/LiveSectors.config.js
+++ b/plugins/ui/dynamic_components/checkpoint_windows/LiveSectors.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import icons from '../../config/Icons.js'
 import ids from '../../config/ComponentIds.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   entries: 15,
   cpsOnFirstPage: 10,
   icon: icons.chartLocal,
@@ -57,3 +58,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/checkpoint_windows/LocalCps.config.js
+++ b/plugins/ui/dynamic_components/checkpoint_windows/LocalCps.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import icons from '../../config/Icons.js'
 import ids from '../../config/ComponentIds.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   entries: 15,
   cpsOnFirstPage: 8,
   icon: icons.chartLocal,
@@ -57,3 +58,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/dynamic_components/checkpoint_windows/LocalSectors.config.js
+++ b/plugins/ui/dynamic_components/checkpoint_windows/LocalSectors.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import icons from '../../config/Icons.js'
 import ids from '../../config/ComponentIds.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   entries: 15,
   cpsOnFirstPage: 8,
   icon: icons.chartLocal,
@@ -57,3 +58,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/AdminPanel.config.js
+++ b/plugins/ui/static_components/race/AdminPanel.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   height: 5,
   width: cfg.width,
   privilege: 1,
@@ -39,3 +40,5 @@ export default {
     endRound: `${p.admin}#{title} ${p.highlight}#{adminName} ${p.admin}has forced the ongoing round to end.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/BestCps.config.js
+++ b/plugins/ui/static_components/race/BestCps.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entryHeight: 2.16,
   entries: 6,
   width: cfg.width,
@@ -27,3 +28,5 @@ export default {
   horizontalMaxRows: 5,
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/BestFinishes.config.js
+++ b/plugins/ui/static_components/race/BestFinishes.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
 let entries = 7
 
-export default {
+const defaultConfig = {
   entryHeight: 2.16,
   entries,
   width: cfg.width,
@@ -24,3 +25,5 @@ export default {
   horizontal: false,
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/CpCounter.config.js
+++ b/plugins/ui/static_components/race/CpCounter.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   height: 2.17,
   width: cfg.width, // Change this ONLY if you want the widget to be on the side
   useRelative: false,
@@ -41,3 +42,5 @@ export default {
   finishTextDuration: 3000,
   hidePanel: false
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/DediRanking.config.js
+++ b/plugins/ui/static_components/race/DediRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 15,
   teamsEntries: 15,
   roundsEntries: 7,
@@ -20,3 +21,5 @@ export default {
   displayNoRecordEntry: true,
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/DonationPanel.config.js
+++ b/plugins/ui/static_components/race/DonationPanel.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   title: 'Donations',
   height: 4.49,
   width: cfg.width,
@@ -11,3 +12,5 @@ export default {
   hidePanel: true,
   amounts: [50, 100, 200, 500, 1000, 5000]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/KarmaWidget.config.js
+++ b/plugins/ui/static_components/race/KarmaWidget.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   height: 8.8,
   width: cfg.width,
   title: 'Karma',
@@ -27,3 +28,5 @@ export default {
     offset: -0.3
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/LapRanking.config.js
+++ b/plugins/ui/static_components/race/LapRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 7,
   entryHeight: 2.15,
   width: cfg.width,
@@ -12,3 +13,5 @@ export default {
   displayNoRecordEntry: true,
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/LiveRanking.config.js
+++ b/plugins/ui/static_components/race/LiveRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 6,
   lapsEntries: 12,
   stuntsEntries: 8,
@@ -21,3 +22,5 @@ export default {
   hidePanel: true,
   maxRecordsAmount: 3000 // If more records than this get driven in one round the click listener will break
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/LocalRanking.config.js
+++ b/plugins/ui/static_components/race/LocalRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 15,
   teamsEntries: 7,
   roundsEntries: 7,
@@ -23,3 +24,5 @@ export default {
   hidePanel: true,
   stuntsNoRecordEntry: '--'
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/MapWidget.config.js
+++ b/plugins/ui/static_components/race/MapWidget.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   // Here height is 4 headers with margin
   height: 9.13,
   margin: cfg.margin,
@@ -49,3 +50,5 @@ export default {
     nextTrack: 'Next Map'
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/PreviousAndBest.config.js
+++ b/plugins/ui/static_components/race/PreviousAndBest.config.js
@@ -1,8 +1,11 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 
-export default {
+const defaultConfig = {
   height: 4.95,
   width: cfg.width,
   margin: cfg.margin,
   background: cfg.background
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/RankWidget.config.js
+++ b/plugins/ui/static_components/race/RankWidget.config.js
@@ -1,7 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 
-export default {
+const defaultConfig = {
   height: 3.8,
   width: cfg.width,
   background: cfg.background
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/RoundScore.config.js
+++ b/plugins/ui/static_components/race/RoundScore.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   roundsEntries: 12,
   teamsEntries: 10,
   cupEntries: 12,
@@ -23,3 +24,5 @@ export default {
   },
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/RoundsPointsRanking.config.js
+++ b/plugins/ui/static_components/race/RoundsPointsRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 8,
   cupEntries: 8,
   entryHeight: 2.15,
@@ -21,3 +22,5 @@ export default {
   cupImageHorizontalPadding: 0.3,
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/TMXRanking.config.js
+++ b/plugins/ui/static_components/race/TMXRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 3, // when changing this value, change topCount as well. // TODO: RecordList->getDisplayedRecords()
   entryHeight: 2.15,
   width: cfg.width,
@@ -13,3 +14,5 @@ export default {
   displayNoRecordEntry: false,
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/TeamScore.config.js
+++ b/plugins/ui/static_components/race/TeamScore.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   height: 5.5,
   width: cfg.width,
   margin: cfg.margin,
@@ -23,3 +24,5 @@ export default {
   noMaxScore: '-',
   hidePanel: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/TimerWidget.config.js
+++ b/plugins/ui/static_components/race/TimerWidget.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import icons from '../../config/Icons.js'
 import cfg from '../../config/RaceUi.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   height: 6.45,
   stuntsDynamicMarginTop: 5.5,
   stuntsHeight: 6.45 + 5.5,
@@ -39,3 +40,5 @@ export default {
   resume: `${p.admin}#{title} ${p.highlight}#{adminName} ${p.admin}has ${p.highlight}resumed ${p.admin}the timer.`,
   set: `${p.admin}#{title} ${p.highlight}#{adminName} ${p.admin}has set the remaining time to ${p.highlight}#{time}${p.admin}.`
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/UltiRanking.config.js
+++ b/plugins/ui/static_components/race/UltiRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/RaceUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 12,
   teamsEntries: 15,
   roundsEntries: 7,
@@ -22,3 +23,5 @@ export default {
   maxRecordCount: 5000,
   noRecordEntryText: '--'
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/buttons/ButtonsWidget.config.js
+++ b/plugins/ui/static_components/race/buttons/ButtonsWidget.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../../src/ConfigLoader.js"
 import cfg from '../../../config/RaceUi.js'
 import icons from '../../../config/Icons.js'
 
 const palette = tm.utils.palette
 
-export default {
+const defaultConfig = {
   height: 14.5,
   width: cfg.width,
   margin: cfg.margin,
@@ -283,3 +284,5 @@ export default {
   },
   hidePanel: false
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/race/buttons/Messages.config.js
+++ b/plugins/ui/static_components/race/buttons/Messages.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../../src/ConfigLoader.js"
 const p = tm.utils.palette
 import buttonCfg from './ButtonsWidget.config.js'
 
-export default {
+const defaultConfig = {
   paySkip: {
     paymentFail: `${p.error}Failed to process payment.`,
     success: `${p.highlight}#{name}${p.donation} has paid ${p.highlight}#{amount}C ${p.donation}to skip the ongoing map.` + ` Skipping in ${p.highlight}#{seconds}s${p.donation}.`
@@ -48,4 +49,6 @@ export default {
     cancelled: `${p.vote} Vote to #{action} the ongoing map was cancelled.`,
     cancelledBy: `${p.vote}#{title} ${p.highlight}#{nickname}${p.vote} has cancelled the vote to #{action} the ongoing map.`
   }
-} 
+}
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/AdminPanelResult.config.js
+++ b/plugins/ui/static_components/result/AdminPanelResult.config.js
@@ -1,9 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   height: 5,
   width: cfg.width,
   privilege: 1,
@@ -33,3 +34,5 @@ export default {
     shuffle: `${p.admin}#{title} ${p.highlight}#{adminName} ${p.admin}has shuffled the queue.`
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/AveragesRanking.config.js
+++ b/plugins/ui/static_components/result/AveragesRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -12,4 +13,6 @@ export default {
   columnProportions: [1, 1.9, 5.1],
   topCount: 5,
   displayNoRecordEntry: true
-} 
+}
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/BannerWidget.config.js
+++ b/plugins/ui/static_components/result/BannerWidget.config.js
@@ -1,9 +1,11 @@
-import { resultConfig as cfg, StaticHeader } from '../../UI.js'
+import { loadConfig } from "../../../../src/ConfigLoader.js"
+import cfg from '../../config/ResultUi.js'
+import StaticHeader from '../../utils/StaticHeader.js'
 
 /**
  * Banner image ratio is around 4:1
  */
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   image: 'https://trakman.ptrk.eu/icons/CrazyTrakman.png',
@@ -22,3 +24,5 @@ export default {
   topBorder: cfg.topBorder,
   marginBig: cfg.marginBig
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/DediRankingResult.config.js
+++ b/plugins/ui/static_components/result/DediRankingResult.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -11,3 +12,5 @@ export default {
   topCount: 5,
   displayNoRecordEntry: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/DonatorsRanking.config.js
+++ b/plugins/ui/static_components/result/DonatorsRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -14,3 +15,5 @@ export default {
   background: cfg.background,
   columnProportions: [1, 1.9, 5.1]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/KarmaRanking.config.js
+++ b/plugins/ui/static_components/result/KarmaRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -13,3 +14,5 @@ export default {
   minimumVotes: 5,
   columnProportions: [1, 1.9, 5.1]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/KarmaWidgetResult.config.js
+++ b/plugins/ui/static_components/result/KarmaWidgetResult.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   height: 8.8,
   width: cfg.width,
   title: 'Karma',
@@ -26,3 +27,5 @@ export default {
     offset: -0.3
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/LocalRankingResult.config.js
+++ b/plugins/ui/static_components/result/LocalRankingResult.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -11,3 +12,5 @@ export default {
   topCount: 5,
   displayNoRecordEntry: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/MapWidgetResult.config.js
+++ b/plugins/ui/static_components/result/MapWidgetResult.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   // Here height is 5 headers with margin
   height: 11.4,
   margin: cfg.margin,
@@ -59,3 +60,5 @@ export default {
     nextTrack: 'Next Map'
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/MostRecordsRanking.config.js
+++ b/plugins/ui/static_components/result/MostRecordsRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -14,3 +15,5 @@ export default {
   background: cfg.background,
   columnProportions: [1, 1.9, 5.1]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/NextMapRecords.config.js
+++ b/plugins/ui/static_components/result/NextMapRecords.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -12,3 +13,5 @@ export default {
   topCount: 5,
   displayNoRecordEntry: true
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/PlaytimeRanking.config.js
+++ b/plugins/ui/static_components/result/PlaytimeRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -14,3 +15,5 @@ export default {
   background: cfg.background,
   columnProportions: [1, 1.9, 5.1]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/RankWidgetResult.config.js
+++ b/plugins/ui/static_components/result/RankWidgetResult.config.js
@@ -1,7 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 
-export default {
+const defaultConfig = {
   height: 6.5,
   width: cfg.width,
   background: cfg.background
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/RoundAveragesRanking.config.js
+++ b/plugins/ui/static_components/result/RoundAveragesRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -15,3 +16,4 @@ export default {
   columnProportions: [1, 2.9, 4.1]
 }
 
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/TimerWidgetResult.config.js
+++ b/plugins/ui/static_components/result/TimerWidgetResult.config.js
@@ -1,7 +1,10 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 
-export default {
+const defaultConfig = {
   height: 6.1,
   width: cfg.width,
   background: cfg.background
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/VisitorsRanking.config.js
+++ b/plugins/ui/static_components/result/VisitorsRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -11,3 +12,5 @@ export default {
   background: cfg.background,
   columnProportions: [1, 1.9, 5.1]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/VotersRanking.config.js
+++ b/plugins/ui/static_components/result/VotersRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -11,3 +12,5 @@ export default {
   background: cfg.background,
   columnProportions: [1, 1.9, 5.1]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/static_components/result/WinnersRanking.config.js
+++ b/plugins/ui/static_components/result/WinnersRanking.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../../src/ConfigLoader.js"
 import cfg from '../../config/ResultUi.js'
 import icons from '../../config/Icons.js'
 
-export default {
+const defaultConfig = {
   entries: 5,
   entryHeight: 2.15,
   width: cfg.width,
@@ -14,3 +15,5 @@ export default {
   background: cfg.background,
   columnProportions: [1, 1.9, 5.1]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/test_widgets/TestWidget.config.js
+++ b/plugins/ui/test_widgets/TestWidget.config.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: true,
   file: 'test.xml',
   refreshTimeout: 1000,
@@ -15,3 +16,5 @@ export default {
     }
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/CloseButton.config.js
+++ b/plugins/ui/utils/CloseButton.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 
-export default {
+const defaultConfig = {
   buttonWidth: 3,
   buttonHeight: 3,
   icon: icons.close,
@@ -8,3 +9,5 @@ export default {
   padding: 0.2,
   background: '000D'
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/List.config.js
+++ b/plugins/ui/utils/List.config.js
@@ -1,4 +1,7 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   textScale: 0.85,
   margin: 0.15
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/Navbar.config.js
+++ b/plugins/ui/utils/Navbar.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 
-export default {
+const defaultConfig = {
   height: 3.5,
   textScale: 0.75,
   margin: 0.15,
@@ -8,3 +9,5 @@ export default {
   background: '000C',
   hoverImage: icons.bgGreyOpaque50
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/Paginator.config.js
+++ b/plugins/ui/utils/Paginator.config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 
-export default {
+const defaultConfig = {
   buttonWidth: 3,
   buttonHeight: 3,
   margin: 0.4,
@@ -11,3 +12,5 @@ export default {
   iconsHover: [icons.pageFirstHover, icons.pageDoubleLeftHover, icons.pageLeftHover, icons.pageRightHover,
     icons.pageDoubleRightHover, icons.pageLastHover]
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/RecordListRace.config.js
+++ b/plugins/ui/utils/RecordListRace.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 import cfg from '../config/RaceUi.js'
 
-export default {
+const defaultConfig = {
   columnProportions: [1, 2.9, 4.1],
   background: cfg.background,
   headerBackground: '000a',
@@ -40,3 +41,5 @@ export default {
   noRecordEntryText: '-:--.--',
   maxCpCount: 500 // prevents crashes in case theres too many cps to display
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/RecordListResult.config.js
+++ b/plugins/ui/utils/RecordListResult.config.js
@@ -1,7 +1,8 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 import cfg from '../config/ResultUi.js'
 
-export default {
+const defaultConfig = {
   columnProportions: [1, 2.9, 4.1],
   background: cfg.background,
   headerBackground: '8886',
@@ -40,3 +41,5 @@ export default {
   noRecordEntryText: '-:--.--',
   maxCpCount: 500 // prevents crashes in case theres too many cps to display
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/StaticButton.config.js
+++ b/plugins/ui/utils/StaticButton.config.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   background: '000a',
   yOffsetBig: 2.2,
   yOffset: 2.4,
@@ -10,3 +11,5 @@ export default {
   iconHeight: 1.8,
   topPadding: 0.2
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/StaticHeaderRace.config.js
+++ b/plugins/ui/utils/StaticHeaderRace.config.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   format: '$s',
   textBackground: '000a',
   iconBackground: '000a',
@@ -15,3 +16,5 @@ export default {
   iconVerticalPadding: 0.1,
   centerText: false
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/StaticHeaderResult.config.js
+++ b/plugins/ui/utils/StaticHeaderResult.config.js
@@ -1,4 +1,5 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   format: '$s',
   textBackground: '8886',
   iconBackground: '8886',
@@ -15,3 +16,5 @@ export default {
   iconVerticalPadding: 0.1,
   centerText: false
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/TextUtils.config.js
+++ b/plugins/ui/utils/TextUtils.config.js
@@ -1,6 +1,9 @@
-export default {
+import { loadConfig } from "../../../src/ConfigLoader.js"
+const defaultConfig = {
   format: '$s',
   textScale: 0.7,
   padding: 0.2,
   yOffset: -0.1
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ui/utils/VoteWindow.config.js
+++ b/plugins/ui/utils/VoteWindow.config.js
@@ -1,10 +1,11 @@
+import { loadConfig } from "../../../src/ConfigLoader.js"
 import icons from '../config/Icons.js'
 import cfg from '../config/RaceUi.js'
 import header from './StaticHeaderRace.config.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   title: ' Vote ',
   width: 25,
   height: 10, // Without the admin buttons
@@ -36,3 +37,5 @@ export default {
     textScale: 1.2
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ultimania/Config.js
+++ b/plugins/ultimania/Config.js
@@ -1,5 +1,8 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: false,
   syncName: true, // If true, sets player nicknames in the database to those fetched from Ultimania
   host: `http://ultimania5.askuri.de/api/v5`
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/ultimania/ui/UltiRecords.config.js
+++ b/plugins/ultimania/ui/UltiRecords.config.js
@@ -1,8 +1,10 @@
-import { componentIds as ids, icons } from '../../ui/UI.js'
+import { loadConfig } from "../../../src/ConfigLoader.js"
+import ids from '../../ui/config/ComponentIds.js'
+import icons from '../../ui/config/Icons.js'
 
 const p = tm.utils.palette
 
-export default {
+const defaultConfig = {
   entries: 15,
   cpsOnFirstPage: 10,
   icon: icons.chartDedi,
@@ -39,3 +41,5 @@ export default {
     privilege: 0
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/vote/Config.js
+++ b/plugins/vote/Config.js
@@ -1,6 +1,7 @@
+import { loadConfig } from "../../src/ConfigLoader.js"
 const passCancelPrivilege = 1
 
-export default {
+const defaultConfig = {
   yesKey: 'F5', // keys can be either F5 F6 or F7
   noKey: 'F6',
   keyListenerImportance: 10,
@@ -28,3 +29,5 @@ export default {
     }
   }
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/plugins/webservices/Config.js
+++ b/plugins/webservices/Config.js
@@ -1,4 +1,7 @@
-export default {
+import { loadConfig } from "../../src/ConfigLoader.js"
+const defaultConfig = {
   isEnabled: true,
   cacheSize: 30
 }
+
+export default await loadConfig(defaultConfig, import.meta.url)

--- a/src/ConfigLoader.ts
+++ b/src/ConfigLoader.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const CONFIG_OVERRIDES_DIR_ENV = 'CONFIG_OVERRIDES_DIR'
+
+let overridePathsPromise: Promise<Set<string>> | undefined
+let overridePaths = new Set<string>()
+let overridesDirPath = ''
+let loadedOverrideCount = 0
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function mergeConfig(defaultValue: unknown, overrideValue: unknown): unknown {
+  if (overrideValue === undefined) {
+    return defaultValue
+  }
+  if (Array.isArray(defaultValue)) {
+    return Array.isArray(overrideValue) ? overrideValue : defaultValue
+  }
+  if (isPlainObject(defaultValue) && isPlainObject(overrideValue)) {
+    const merged: Record<string, unknown> = { ...defaultValue }
+    for (const [key, value] of Object.entries(overrideValue)) {
+      merged[key] = mergeConfig(defaultValue[key], value)
+    }
+    return merged
+  }
+  return overrideValue
+}
+
+function getRelativeConfigPath(modulePath: string): string {
+  const cwd = process.cwd()
+  const builtRoot = path.join(cwd, 'built')
+  if (modulePath.startsWith(`${builtRoot}${path.sep}`)) {
+    return path.relative(builtRoot, modulePath)
+  }
+  if (modulePath.startsWith(`${cwd}${path.sep}`)) {
+    return path.relative(cwd, modulePath)
+  }
+  const builtSegment = `${path.sep}built${path.sep}`
+  const builtIndex = modulePath.lastIndexOf(builtSegment)
+  if (builtIndex !== -1) {
+    return modulePath.substring(builtIndex + builtSegment.length)
+  }
+  return path.basename(modulePath)
+}
+
+function getOverridesDir(): string | undefined {
+  const configured = process.env[CONFIG_OVERRIDES_DIR_ENV]
+  if (typeof configured === 'string' && configured.trim() !== '') {
+    return path.resolve(configured)
+  }
+  return undefined
+}
+
+function normalizePath(value: string): string {
+  return value.split(path.sep).join('/')
+}
+
+async function getOverridePaths(): Promise<Set<string>> {
+  if (overridePathsPromise !== undefined) {
+    return overridePathsPromise
+  }
+
+  overridePathsPromise = (async () => {
+    const maybeOverridesDir = getOverridesDir()
+    if (maybeOverridesDir === undefined) {
+      overridePaths = new Set()
+      return overridePaths
+    }
+    overridesDirPath = maybeOverridesDir
+    try {
+      const entries = await fs.readdir(overridesDirPath, {
+        recursive: true,
+        withFileTypes: true
+      })
+      overridePaths = new Set(entries
+        .filter(a => a.isFile() && a.name.endsWith('.js'))
+        .map(a => {
+          const p = path.join(a.parentPath, a.name)
+          return normalizePath(path.relative(overridesDirPath, p))
+        }))
+    } catch {
+      overridePaths = new Set()
+    }
+    return overridePaths
+  })()
+
+  return overridePathsPromise
+}
+
+export async function loadConfig<T>(defaultConfig: T, moduleUrl: string): Promise<T> {
+  const modulePath = fileURLToPath(moduleUrl)
+  const relativeConfigPath = normalizePath(getRelativeConfigPath(modulePath))
+  const paths = await getOverridePaths()
+
+  if (!paths.has(relativeConfigPath)) {
+    return defaultConfig
+  }
+
+  const overridePath = path.resolve(overridesDirPath, relativeConfigPath)
+
+  try {
+    const overrideModule = await import(pathToFileURL(overridePath).href)
+    const overrideConfig = (overrideModule.default ?? overrideModule) as unknown
+
+    if (!isPlainObject(overrideConfig) && !Array.isArray(defaultConfig)) {
+      return defaultConfig
+    }
+    loadedOverrideCount++
+    return mergeConfig(defaultConfig, overrideConfig) as T
+  } catch {
+    return defaultConfig
+  }
+}
+
+export function getLoadedConfigOverrideCount(): number {
+  return loadedOverrideCount
+}
+
+export { CONFIG_OVERRIDES_DIR_ENV }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -13,9 +13,12 @@ import { AdministrationService } from './services/AdministrationService.js'
 import { VoteService } from './services/VoteService.js'
 import { RoundsService } from './services/RoundsService.js'
 import { fixRankCoherence } from './FixRankCoherence.js'
+import * as ConfigLoader from './ConfigLoader.js'
 import 'dotenv/config'
 import * as readline from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import config from '../config/Config.js'
 import './Trakman.js'
 
@@ -48,6 +51,21 @@ await GameService.initialize()
 Logger.trace('Game info fetched')
 // import plugins after initializing database to avoid process exiting with no error in case of query on non-existent table
 await import('../Plugins.js')
+const externalPlugins: unknown[] = Array.isArray(config.externalPlugins) ? config.externalPlugins : []
+for (const pluginPath of externalPlugins) {
+  if (typeof pluginPath !== 'string' || pluginPath.trim() === '') {
+    Logger.warn(`Ignoring invalid external plugin path: ${String(pluginPath)}`)
+    continue
+  }
+  try {
+    const resolvedPath = path.isAbsolute(pluginPath) ? pluginPath : path.resolve(process.cwd(), pluginPath)
+    await import(pathToFileURL(resolvedPath).href)
+    Logger.trace(`Loaded external plugin: ${pluginPath}`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    Logger.error(`Failed to load external plugin: ${pluginPath}`, message)
+  }
+}
 Logger.trace('Fetching player info...')
 await PlayerService.initialize()
 Logger.trace('Player service instantiated')
@@ -80,6 +98,8 @@ if (cb instanceof Error) {
 Logger.trace('Callbacks enabled')
 await Events.initialize()
 Logger.trace('Controller events enabled')
+const loadedOverrideCount = ConfigLoader.getLoadedConfigOverrideCount()
+Logger.info(`Loaded ${loadedOverrideCount} config override file${loadedOverrideCount === 1 ? '' : 's'}.`)
 Logger.info('Controller started successfully')
 
 let running = true


### PR DESCRIPTION
Right now, it is very annoying to update trakman especially with Docker containers (also the Update.js script is broken on dev), because the user needs to manually go in and review the changes that have been made. With this approach, we could instead ship the container with a statically compiled version of Trakman, and the user can configure the controller through adding config overrides, as example:

`export default {
  title: 'test2'
}`

inside overrides/plugins/ui/static_components/race/LiveRanking.config.js, which will have priority over the Trakman "default" config.

I already ship my servers with a static version of trakman, but this way i could come closer to upstream again, and i have helped a person to deploy a trakman server using docker, through which i noticed that the current process is not ideal.

This pr also adds the functionality to add extra plugins, which i can load through overriding the Config.js file as example with the following content:

`export default {
  externalPlugins: [
    '../custom_plugins/emojis/Emojis.ts'
  ]
}`

This would load my custom emojis plugin, which resides in a different folder. For users that run it bare metal, they could still change the files as they did before, or they might adapt to using it aswell.

It is not ideal yet, i would love to get some feedback on it.