### PR TITLE
Add option to delete map from the filesystem for manual map loading

### DIFF
--- a/config/Config.js
+++ b/config/Config.js
@@ -59,6 +59,10 @@ export default {
     mapsDirectory: '',
     /** Ignore non-stadium maps */
     stadiumOnly: undefined,
+    /** Delete map files from disk when maps are removed */
+    deleteMap: false,
+    /** Optional map uid that should be skipped by manual map parsing and file deletion */
+    skipId: undefined,
     /** Amount of maps to load into the server. Default value: 5 */
     preloadMaps: 5
   },

--- a/src/services/ManualMapLoading.ts
+++ b/src/services/ManualMapLoading.ts
@@ -64,6 +64,10 @@ export class ManualMapLoading {
           voteRatio: 0,
           voteCount: 0
         }
+        if (config.manualMapLoading.skipId !== undefined && mapObject.id === config.manualMapLoading.skipId) {
+          Logger.info(`Not parsing ${map.FileName} because it is defined inside the config`)
+          continue
+        }
         parsed.add(mapObject.id)
         addedMaps.add(mapObject)
       } else {

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -6,6 +6,7 @@ import { Utils } from '../Utils.js'
 import config from '../../config/Config.js'
 import { GameService } from './GameService.js'
 import { ManualMapLoading } from './ManualMapLoading.js'
+import { promises as fs } from 'node:fs'
 
 interface JukeboxMap {
   readonly map: tm.Map
@@ -476,6 +477,7 @@ export class MapService {
     login: string,
     nickname: string
   }): Promise<boolean | Error> {
+    const skipId = config.manualMapLoading.skipId
     const map: tm.Map | undefined = this._maps.find(a => id === a.id)
     await Client.call('GetChallengeList', [{ int: 5000 }, { int: 0 }]) // I HAVE NO CLUE HOW IT WORKS WITH THIS
     if (map === undefined) {
@@ -504,6 +506,36 @@ export class MapService {
     })
     await this.removeFromQueue(id, caller, false)
     //await this.writeMatchSettings()
+    if (config.manualMapLoading.deleteMap && config.manualMapLoading.enabled) {
+      if (skipId !== undefined && map.id === skipId) {
+        Logger.info(`Not deleting ${map.fileName} because it is defined inside the config`)
+        if (caller !== undefined) {
+          tm.sendMessage(`${Utils.strip(map.fileName)} is configured to not be deleted from the filesystem.`,
+            caller.login)
+        }
+      } else {
+        const file = config.manualMapLoading.mapsDirectoryPrefix + map.fileName
+        Logger.info(`Deleting track file ${file}`)
+        try {
+          await fs.unlink(file)
+          if (caller !== undefined) {
+            tm.sendMessage(`${Utils.strip(map.fileName)} was deleted from disk.`, caller.login)
+          }
+        } catch (err: any) {
+          if (err?.code === 'ENOENT') {
+            Logger.warn(`File ${file} already missing, skipping unlink`)
+            if (caller !== undefined) {
+              tm.sendMessage(`${Utils.strip(map.fileName)} was already missing on disk.`, caller.login)
+            }
+          } else {
+            Logger.error(`Failed to unlink ${file}: ${err?.message}`)
+            if (caller !== undefined) {
+              tm.sendMessage(`Error deleting ${Utils.strip(map.fileName)}: ${err?.message}`, caller.login)
+            }
+          }
+        }
+      }
+    }
     return true
   }
 


### PR DESCRIPTION
Having deployed many servers with manual maploading (which is very convenient btw), i found it to be annoying that the files do not actually get deleted from the server, meaning when i do //udm, it will come back. This option makes sure that it is removed from the filesystem.

If the file is busy, it will wait for it to not be busy (after skip) to delete it. I also made sure that there cannot be a race condition where a user is able to delete all of the maps. (which would break the server)

Also adds support for defining a map uid, that will not be parsed by manual map loading and not removed from the filesystem when doing //et or removing it through the maplist ui. This will come in handy as i plan to upstream my placeholder plugin, which makes it so the server always starts with a placeholder map, that will then get skipped if it is not the only map on the server.

That placeholder map will be the only one defined inside the MatchSettings file, making sure the server can launch, but giving the flexibility to be able to remove all maps.