### PR TITLE
Add mod url fetching/saving, add mod overriding flag

### DIFF
--- a/plugins/ui/UI.ts
+++ b/plugins/ui/UI.ts
@@ -31,6 +31,8 @@ import { fullScreenListener } from './utils/FullScreenListener.js'
 import flagIcons from './config/FlagIcons.js'
 import utilIds from './config/UtilIds.js'
 import Buttons from './Buttons.js'
+import { ManualMapLoading } from '../../src/services/ManualMapLoading.js'
+import config from '../../config/Config.js'
 // Has to be like that due to circular dependencies
 import './Imports.js'
 
@@ -47,7 +49,11 @@ const currentModIndex = {
   ...tm.config.controller.customEnvironments.reduce((acc, env) => ({ ...acc, [env]: 0 }), {})
 }
 
-const loadMod = (): void => {
+const loadMod = async (): Promise<void> => {
+  if (!modConfig.enabled) {
+    tm.client.callNoRes('SetForcedMods', [{ boolean: false }, { array: [] }])
+    return
+  }
   const mods: {
     struct: {
       Env: {
@@ -58,7 +64,20 @@ const loadMod = (): void => {
       }
     }
   }[] = []
-  for (const obj of modConfig) {
+  const nextMap = tm.jukebox.queue[0]
+  const nextMapModUrl = config.manualMapLoading.enabled && modConfig.useNextMapModOverride && nextMap !== undefined
+    ? nextMap.modUrl
+    : undefined
+  const nextMapOverride = nextMapModUrl != null ? {
+    environment: nextMap.environment,
+    modLinks: [modConfig.modUrlPrefix + nextMapModUrl],
+    randomOrder: false
+  } : undefined
+  const overrides = nextMapOverride === undefined ? modConfig.overrides : [
+    nextMapOverride,
+    ...modConfig.overrides.filter(a => a.environment !== nextMapOverride.environment)
+  ]
+  for (const obj of overrides) {
     if (obj.modLinks.length === 0) { continue }
     mods.push({
       struct: {
@@ -76,6 +95,26 @@ const loadMod = (): void => {
   }, {
     array: mods
   }])
+}
+
+const sendCurrentMapModUrl = async (login: string): Promise<void> => {
+  const url = tm.maps.current.modUrl
+  if (url === undefined) {
+    tm.sendMessage(modConfig.messages.missing, login)
+    return
+  }
+  tm.sendMessage(tm.utils.strVar(modConfig.messages.current, { url }), login)
+}
+
+if (config.manualMapLoading.enabled) {
+  tm.commands.add({
+    aliases: modConfig.command.aliases,
+    help: modConfig.command.help,
+    callback: (info): void => {
+      void sendCurrentMapModUrl(info.login)
+    },
+    privilege: modConfig.command.privilege
+  })
 }
 
 const iconArr = Object.values(icons.preloadedIcons).map(a => `<quad posn="500 500 0" sizen="10 10" image="${a}"/>`)
@@ -102,7 +141,7 @@ const events: tm.Listener[] = [{
   callback: async (): Promise<void> => {
     await tm.client.call('SendHideManialinkPage')
     preloadIcons()
-    loadMod()
+    await loadMod()
     initalizeKeyListeners()
     customUi = new CustomUi()
     customUi.display()
@@ -133,7 +172,7 @@ const events: tm.Listener[] = [{
   event: 'EndMap',
   callback: async (): Promise<void> => {
     currentModIndex[tm.maps.current.environment as keyof typeof currentModIndex]++
-    loadMod()
+    await loadMod()
   }
 }, {
   event: 'PlayerJoin',
@@ -201,4 +240,3 @@ const addLoadListener = (callback: Function): void => {
 export {
   Paginator, Grid, Navbar, VoteWindow, RecordList, type GridCellFunction, type GridCellObject, List, StaticHeader, PopupWindow, StaticComponent, DynamicComponent, type StaticHeaderOptions, type RLImage, type RLRecord, components, componentIds, icons, raceConfig, resultConfig, flagIcons, utilIds, addKeyListener, removeKeyListener, rightAlignedText, getCpTypes, closeButton, horizontallyCenteredText, staticButton, fullScreenListener, centeredText, addLoadListener, leftAlignedText, addManialinkListener, removeManialinkListener
 }
-

--- a/plugins/ui/config/Mod.js
+++ b/plugins/ui/config/Mod.js
@@ -1,31 +1,51 @@
-export default // Environments are Stadium, Desert, Snow, Bay, Coast, Island, Rally
-// If random order is disabled, mods array will be applied in order
-[{
-  environment: 'Stadium',
-  modLinks: [`https://trakman.ptrk.eu/TrakmanMod.zip`],
-  randomOrder: true
-}, {
-  environment: 'Desert',
-  modLinks: [`https://trakman.ptrk.eu/TrakmanMod.zip`],
-  randomOrder: true
-}, {
-  environment: 'Snow',
-  modLinks: [`https://trakman.ptrk.eu/TrakmanMod.zip`],
-  randomOrder: true
-}, {
-  environment: 'Bay',
-  modLinks: [`https://trakman.ptrk.eu/TrakmanMod.zip`],
-  randomOrder: true
-}, {
-  environment: 'Coast',
-  modLinks: [`https://trakman.ptrk.eu/TrakmanMod.zip`],
-  randomOrder: true
-}, {
-  environment: 'Island',
-  modLinks: [`https://trakman.ptrk.eu/TrakmanMod.zip`],
-  randomOrder: true
-}, {
-  environment: 'Rally',
-  modLinks: [`https://trakman.ptrk.eu/TrakmanMod.zip`],
-  randomOrder: true
-}]
+const p = tm.utils.palette
+
+export default {
+  enabled: true,
+  // Only supported with manual maploading
+  useNextMapModOverride: false,
+  // Can be used to provide a endpoint that serves a zip injecting UI mods into the zip (if you don't understand what this means, leave the default)
+  modUrlPrefix: '',
+  command: {
+    aliases: ['mod'],
+    help: 'Display the current map mod URL.',
+    privilege: 0
+  },
+  messages: {
+    current: `${p.highlight}Current map mod: $l$ff0#{url}`,
+    missing: `${p.error}This map has no external mod URL.`
+  },
+  overrides: [
+    // Environments are Stadium, Desert, Snow, Bay, Coast, Island, Rally
+    // If random order is disabled, mods array will be applied in order
+    {
+      environment: 'Stadium',
+      modLinks: ['https://trakman.ptrk.eu/TrakmanMod.zip'],
+      randomOrder: true
+    }, {
+      environment: 'Desert',
+      modLinks: ['https://trakman.ptrk.eu/TrakmanMod.zip'],
+      randomOrder: true
+    }, {
+      environment: 'Snow',
+      modLinks: ['https://trakman.ptrk.eu/TrakmanMod.zip'],
+      randomOrder: true
+    }, {
+      environment: 'Bay',
+      modLinks: ['https://trakman.ptrk.eu/TrakmanMod.zip'],
+      randomOrder: true
+    }, {
+      environment: 'Coast',
+      modLinks: ['https://trakman.ptrk.eu/TrakmanMod.zip'],
+      randomOrder: true
+    }, {
+      environment: 'Island',
+      modLinks: ['https://trakman.ptrk.eu/TrakmanMod.zip'],
+      randomOrder: true
+    }, {
+      environment: 'Rally',
+      modLinks: ['https://trakman.ptrk.eu/TrakmanMod.zip'],
+      randomOrder: true
+    }
+  ]
+}

--- a/src/Namespace.ts
+++ b/src/Namespace.ts
@@ -46,6 +46,8 @@ declare global {
       leaderboardRating?: number
       /** Map TMX awards (undefined if the map was never fetched from TMX) */
       awards?: number
+      /** External mod archive URL parsed from the GBX header, if present */
+      modUrl?: string | null
     }
 
     /** TM Server Challenge return type */
@@ -61,7 +63,8 @@ declare global {
       BronzeTime?: number,
       SilverTime?: number,
       AuthorTime?: number,
-      NbLaps?: number
+      NbLaps?: number,
+      ModUrl?: string | null
     }
 
     /** Controller online player object */
@@ -739,6 +742,8 @@ declare global {
       readonly NbLaps: number;
       /** Amount of checkpoints (certain methods (eg. GetChallengeInfo, GetNextChallengeInfo) return -1 here for some reason) */
       readonly NbCheckpoints: number;
+      /** External mod archive URL parsed from the GBX header, if present */
+      readonly ModUrl?: string | null;
     }
 
     /** Ranking object received from EndChallenge and EndRace dedicated server callbacks */

--- a/src/database/CreateQueries.ts
+++ b/src/database/CreateQueries.ts
@@ -16,6 +16,7 @@ export const createQueries = [`CREATE TABLE IF NOT EXISTS map_ids(
   gold_time INT4 NOT NULL,
   author_time INT4 NOT NULL,
   copper_price INT4 NOT NULL,
+  mod_url TEXT,
   is_lap_race BOOLEAN NOT NULL,
   add_date TIMESTAMP NOT NULL,
   leaderboard_rating INT4,
@@ -27,6 +28,8 @@ export const createQueries = [`CREATE TABLE IF NOT EXISTS map_ids(
     FOREIGN KEY(id) 
 	    REFERENCES map_ids(id)
   );`,
+
+  'ALTER TABLE maps ADD COLUMN IF NOT EXISTS mod_url TEXT;',
 
   `CREATE TABLE IF NOT EXISTS players(
     id INT4 GENERATED ALWAYS AS IDENTITY,

--- a/src/database/MapRepository.ts
+++ b/src/database/MapRepository.ts
@@ -18,6 +18,7 @@ interface TableEntry {
   readonly gold_time: number
   readonly author_time: number
   readonly copper_price: number
+  readonly mod_url: string | null
   readonly is_lap_race: boolean
   readonly add_date: Date
   readonly leaderboard_rating: number | null
@@ -77,15 +78,15 @@ export class MapRepository extends Repository {
         values.push(
           ([i, map.name.replaceAll('\n', ' '), map.fileName, map.author, environments[map.environment as keyof typeof environments] ?? environments["Stadium"],
             moods[map.mood],
-            map.bronzeTime, map.silverTime, map.goldTime, map.authorTime, map.copperPrice, map.isLapRace,
+            map.bronzeTime, map.silverTime, map.goldTime, map.authorTime, map.copperPrice, map.modUrl, map.isLapRace,
             map.defaultLapsAmount, map.checkpointsPerLap, map.addDate.toISOString(), map.leaderboardRating,
-            map.awards]).map(a => a === undefined ? '\\N' : a.toString()
+            map.awards]).map(a => a == null ? '\\N' : a.toString()
               .replaceAll('\t', ' ').replaceAll('\\', '')).join('\t')) // ugly replace to prevent DB errors
       }
     })
     const bulk = values.join('\n')
     const stream: CopyStreamQuery | Error = this.db.stream(
-      'maps(id, name, filename, author, environment, mood, bronze_time, silver_time, ' + 'gold_time,author_time, copper_price, is_lap_race, laps_amount, checkpoints_amount, add_date, leaderboard_rating, awards)')
+      'maps(id, name, filename, author, environment, mood, bronze_time, silver_time, ' + 'gold_time,author_time, copper_price, mod_url, is_lap_race, laps_amount, checkpoints_amount, add_date, leaderboard_rating, awards)')
     if (stream instanceof Error) {
       await Logger.fatal('Failed to mass-add maps to database', stream)
       return
@@ -108,13 +109,13 @@ export class MapRepository extends Repository {
     }
     if (arr.length === 0) { return }
     const query = `INSERT INTO maps(id, name, filename, author, environment, mood, 
-      bronze_time, silver_time, gold_time, author_time, copper_price, is_lap_race, 
-      laps_amount, checkpoints_amount, add_date, leaderboard_rating, awards) ${this.getInsertValuesString(17,
+      bronze_time, silver_time, gold_time, author_time, copper_price, mod_url, is_lap_race, 
+      laps_amount, checkpoints_amount, add_date, leaderboard_rating, awards) ${this.getInsertValuesString(18,
       ids.length)} ON CONFLICT DO NOTHING`
     const values: any[] = []
     for (const [i, map] of arr.entries()) {
       values.push(ids[i].id, map.name, map.fileName, map.author, environments[map.environment as keyof typeof environments] ?? environments["Stadium"], moods[map.mood],
-        map.bronzeTime, map.silverTime, map.goldTime, map.authorTime, map.copperPrice, map.isLapRace,
+        map.bronzeTime, map.silverTime, map.goldTime, map.authorTime, map.copperPrice, map.modUrl, map.isLapRace,
         map.defaultLapsAmount, map.checkpointsPerLap, map.addDate, map.leaderboardRating, map.awards)
     }
     await this.query(query, ...values)
@@ -132,6 +133,7 @@ export class MapRepository extends Repository {
                           gold_time,
                           author_time,
                           copper_price,
+                          mod_url,
                           is_lap_race,
                           laps_amount,
                           checkpoints_amount,
@@ -143,9 +145,9 @@ export class MapRepository extends Repository {
                             JOIN map_ids ON maps.id = map_ids.id
                             LEFT JOIN votes ON votes.map_id = maps.id
                        ${stadiumOnly ? 'WHERE environment = 1' : ''}
-                   GROUP BY (uid, name, filename, author, environment, mood, bronze_time, silver_time, gold_time,
-                       author_time, copper_price, is_lap_race, laps_amount, checkpoints_amount, add_date,
-                       leaderboard_rating, awards);`
+                    GROUP BY (uid, name, filename, author, environment, mood, bronze_time, silver_time, gold_time,
+                        author_time, copper_price, mod_url, is_lap_race, laps_amount, checkpoints_amount, add_date,
+                        leaderboard_rating, awards);`
     return ((await this.query(query))).map(a => this.constructMapObject(a))
   }
 
@@ -172,6 +174,7 @@ export class MapRepository extends Repository {
                           gold_time,
                           author_time,
                           copper_price,
+                          mod_url,
                           is_lap_race,
                           laps_amount,
                           checkpoints_amount,
@@ -183,9 +186,9 @@ export class MapRepository extends Repository {
                             JOIN map_ids ON maps.id = map_ids.id
                             LEFT JOIN votes ON votes.map_id = maps.id
                    WHERE ${ids.map((_, i) => `id=$${i + 1} OR `).join('').slice(0, -3)}
-                   GROUP BY (uid, name, filename, author, environment, mood, bronze_time, silver_time, gold_time,
-                             author_time, copper_price, is_lap_race, laps_amount, checkpoints_amount, add_date,
-                             leaderboard_rating, awards);`
+                    GROUP BY (uid, name, filename, author, environment, mood, bronze_time, silver_time, gold_time,
+                              author_time, copper_price, mod_url, is_lap_race, laps_amount, checkpoints_amount, add_date,
+                              leaderboard_rating, awards);`
     const res = (await this.query(query, ...ids.map(a => a.id)))
     if (!isArr) {
       return res[0] === undefined ? undefined : this.constructMapObject(res[0])
@@ -214,6 +217,7 @@ export class MapRepository extends Repository {
                           gold_time,
                           author_time,
                           copper_price,
+                          mod_url,
                           is_lap_race,
                           laps_amount,
                           checkpoints_amount,
@@ -225,9 +229,9 @@ export class MapRepository extends Repository {
                             JOIN map_ids ON maps.id = map_ids.id
                             LEFT JOIN votes ON votes.map_id = maps.id
                    WHERE ${fileNames.map((a, i) => `filename=$${i + 1} OR `).join('').slice(0, -3)}
-                   GROUP BY (uid, name, filename, author, environment, mood, bronze_time, silver_time, gold_time,
-                             author_time, copper_price, is_lap_race, laps_amount, checkpoints_amount, add_date,
-                             leaderboard_rating, awards)`
+                    GROUP BY (uid, name, filename, author, environment, mood, bronze_time, silver_time, gold_time,
+                              author_time, copper_price, mod_url, is_lap_race, laps_amount, checkpoints_amount, add_date,
+                              leaderboard_rating, awards)`
     const res = (await this.query(query, ...fileNames))
     if (!isArr) {
       return res[0] === undefined ? undefined : this.constructMapObject({
@@ -354,6 +358,18 @@ export class MapRepository extends Repository {
     await this.query(query, fileName, id)
   }
 
+  async setModUrl(uid: string, modUrl: string | null): Promise<void> {
+    const id = await mapIdsRepo.get(uid)
+    if (id === undefined) {
+      Logger.error(`Failed to get id for map ${uid} while setting mod url in maps table`)
+      return
+    }
+    const query = `UPDATE maps
+                   SET mod_url=$1
+                   WHERE id = $2`
+    await this.query(query, modUrl, id)
+  }
+
   private constructMapObject(entry: TableEntry): tm.Map {
     return {
       id: entry.uid,
@@ -367,6 +383,7 @@ export class MapRepository extends Repository {
       goldTime: entry.gold_time,
       authorTime: entry.author_time,
       copperPrice: entry.copper_price,
+      modUrl: entry.mod_url,
       isLapRace: entry.is_lap_race,
       addDate: entry.add_date,
       defaultLapsAmount: entry.laps_amount ?? undefined,

--- a/src/services/ManualMapLoading.ts
+++ b/src/services/ManualMapLoading.ts
@@ -20,6 +20,19 @@ export class ManualMapLoading {
     return files.map(a => config.manualMapLoading.mapsDirectory + a)
   }
 
+  static parseModUrlFromGbxString(file: string): string | undefined {
+    const modDep = file.match(/<dep\b(?=[^>]*\bfile="Skins\\[^"]*\\Mod\\[^"]*")(?=[^>]*\burl="[^"]+")[^>]*\/?>/im)?.[0]
+    return modDep?.match(/\burl="([^"]+)"/i)?.[1]
+  }
+
+  static async getModUrl(filename: string): Promise<string | undefined> {
+    const file = await fs.readFile(this.prefix + filename).catch(() => undefined)
+    if (file === undefined) {
+      return undefined
+    }
+    return this.parseModUrlFromGbxString(file.toString())
+  }
+
   /**
    * Parse every map in the `config.mapsDirectoryPrefix/config.mapsDirectory
    * @param presentMaps list of already existing maps to compare with
@@ -131,6 +144,7 @@ export class ManualMapLoading {
     const silverTime = file.match(/silver=".*?"/gm)?.[0].slice(8, -1)
     const authorTime = file.match(/authortime=".*?"/gm)?.[0].slice(12, -1)
     const nbLaps = file.match(/nblaps=".*?"/gm)?.[0].slice(8, -1)
+    const modUrl = this.parseModUrlFromGbxString(file)
     return {
       Name: name,
       UId: uid,
@@ -143,7 +157,8 @@ export class ManualMapLoading {
       BronzeTime: bronzeTime == undefined ? 0 : parseInt(bronzeTime),
       SilverTime: silverTime == undefined ? 0 : parseInt(silverTime),
       AuthorTime: authorTime == undefined ? 0 : parseInt(authorTime),
-      NbLaps: nbLaps == undefined ? 0 : Math.min(Math.max(parseInt(nbLaps), 32767), -32768)
+      NbLaps: nbLaps == undefined ? 0 : Math.min(Math.max(parseInt(nbLaps), 32767), -32768),
+      ModUrl: modUrl
     }
   }
 

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -4,6 +4,7 @@ import { MapRepository } from '../database/MapRepository.js'
 import { Events } from '../Events.js'
 import { Utils } from '../Utils.js'
 import config from '../../config/Config.js'
+import modConfig from '../../plugins/ui/config/Mod.js'
 import { GameService } from './GameService.js'
 import { ManualMapLoading } from './ManualMapLoading.js'
 
@@ -159,6 +160,12 @@ export class MapService {
       // fast difference of maps and remaining
       const mapSet = new Set(this._maps.map(a => a.id))
       for (const v of mapIds.values()) {
+        const existing = this._maps.find(a => a.id === v)
+        if (existing !== undefined && modConfig.useNextMapModOverride) {
+          const modUrl = await ManualMapLoading.getModUrl(existing.fileName) ?? null
+          existing.modUrl = modUrl
+          await this.repo.setModUrl(existing.id, modUrl)
+        }
         if (!addedMapIds.delete(v) && !mapSet.delete(v)) {
           removedMaps.push(v)
         }
@@ -799,7 +806,8 @@ export class MapService {
       checkpointsPerLap: info.NbCheckpoints === -1 ? undefined : info.NbCheckpoints,
       addDate: new Date(),
       isNadeo: false,
-      isClassic: false
+      isClassic: false,
+      modUrl: info.ModUrl ?? null
     }
   }
 


### PR DESCRIPTION
Could be useful for RPG servers, or in general servers that want to enable mods. This makes it so if the map has a mod configured, it will get priority over the defined ui mods. I also added a "modUrlPrefix" config option, because i plan to create a endpoint, that takes in the url, and then returns a zip with the UI "mods" injected.

Also changes the database schema so it saves it into the database and backfills with //udm if useNextMapModOverride is enabled.